### PR TITLE
Merge 'Feature manager'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # IDE Settings
 .idea
+
+# VSCode Settings
+.vscode
+
+# PyTest Cache
+.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@
 
 # VSCode Settings
 .vscode
-
-# PyTest Cache
-.pytest_cache

--- a/extension/changelog.js
+++ b/extension/changelog.js
@@ -15,6 +15,7 @@ export default [
 				{ message: "Add an alert for stock system dumps.", contributor: "DeKleineKobini" },
 				{ message: "Customizable api usage.", contributor: "DeKleineKobini" },
 				{ message: "Show muggable money when using a company special to show money on hand.", contributor: "DeKleineKobini" },
+				{ message: "Display features on each page including their status: running/disabled/failed.", contributor: "Mephiles" },
 			],
 			fixes: [{ message: "Hide new chat messages while searching.", contributor: "DeKleineKobini" }],
 			changes: [

--- a/extension/pages/settings/preferences.css
+++ b/extension/pages/settings/preferences.css
@@ -219,3 +219,19 @@ body.dark #preferences #hide-areas span {
 	top: -13px;
 	transform: rotate(-90deg);
 }
+
+/* FeatureDisplayDemo */
+#featureDisplayDemo {
+	border: 1px solid lightgray;
+	border-radius: 10px;
+	padding: 3px;
+	width: 70px;
+	height: 40px;
+	position: relative;
+	margin-left: 20px;
+}
+#featureDisplayDemo input[type="radio"] {position: absolute;}
+#featureDisplayDemo .top {top: 1px;}
+#featureDisplayDemo .bottom {bottom: 1px;}
+#featureDisplayDemo .left {left: 1px;}
+#featureDisplayDemo .right {right: 1px;}

--- a/extension/pages/settings/preferences.css
+++ b/extension/pages/settings/preferences.css
@@ -228,7 +228,7 @@ body.dark #preferences #hide-areas span {
 	width: 70px;
 	height: 40px;
 	position: relative;
-	margin-left: 20px;
+	margin-left: 40px;
 }
 #featureDisplayDemo input[type="radio"] {position: absolute;}
 #featureDisplayDemo .top {top: 1px;}

--- a/extension/pages/settings/settings.html
+++ b/extension/pages/settings/settings.html
@@ -113,6 +113,12 @@
 						<div class="option">
 							<input id="featureDisplay" type="checkbox" />
 							<label for="featureDisplay">Display running features on every page.</label>
+							<div id="featureDisplayDemo">
+								<input type="radio" name="featureDisplayPosition" value="top-left" class="top left">
+								<input type="radio" name="featureDisplayPosition" value="top-right" class="top right" checked>
+								<input type="radio" name="featureDisplayPosition" value="bottom-left" class="bottom left">
+								<input type="radio" name="featureDisplayPosition" value="bottom-right" class="bottom right">
+							</div>
 						</div>
 
 						<div class="header">Page Theme</div>

--- a/extension/pages/settings/settings.html
+++ b/extension/pages/settings/settings.html
@@ -121,6 +121,14 @@
 							</div>
 							<span class="tabbed note">Position for container</span>
 						</div>
+						<div class="option tabbed">
+							<input id="featureDisplayOnlyFails" type="checkbox" >
+							<label for="featureDisplayOnlyFails">Only display failed features</label>
+						</div>
+						<div class="option tabbed">
+							<input id="featureDisplayHideDisabled" type="checkbox">
+							<label for="featureDisplayHideDisabled">Hide disabled features</label>
+						</div>
 
 						<div class="header">Page Theme</div>
 						<div class="option">

--- a/extension/pages/settings/settings.html
+++ b/extension/pages/settings/settings.html
@@ -119,6 +119,7 @@
 								<input type="radio" name="featureDisplayPosition" value="bottom-left" class="bottom left">
 								<input type="radio" name="featureDisplayPosition" value="bottom-right" class="bottom right">
 							</div>
+							<span class="tabbed note">Position for container</span>
 						</div>
 
 						<div class="header">Page Theme</div>

--- a/extension/pages/settings/settings.html
+++ b/extension/pages/settings/settings.html
@@ -110,6 +110,10 @@
 							<input id="updateNotice" type="checkbox" />
 							<label for="updateNotice">Show update notice.</label>
 						</div>
+						<div class="option">
+							<input id="featureDisplay" type="checkbox" />
+							<label for="featureDisplay">Display running features on every page.</label>
+						</div>
 
 						<div class="header">Page Theme</div>
 						<div class="option">

--- a/extension/pages/settings/settings.js
+++ b/extension/pages/settings/settings.js
@@ -380,7 +380,7 @@ async function setupPreferences() {
 	}
 
 	function fillSettings() {
-		for (let setting of ["updateNotice"]) {
+		for (let setting of ["updateNotice", "featureDisplay"]) {
 			const checkbox = _preferences.find(`#${setting}`);
 			if (!checkbox) continue;
 
@@ -672,7 +672,7 @@ async function setupPreferences() {
 	}
 
 	async function saveSettings() {
-		for (let setting of ["updateNotice"]) {
+		for (let setting of ["updateNotice", "featureDisplay"]) {
 			const checkbox = _preferences.find(`#${setting}`);
 			if (!checkbox) continue;
 

--- a/extension/pages/settings/settings.js
+++ b/extension/pages/settings/settings.js
@@ -380,7 +380,7 @@ async function setupPreferences() {
 	}
 
 	function fillSettings() {
-		for (let setting of ["updateNotice", "featureDisplay"]) {
+		for (let setting of ["updateNotice", "featureDisplay", "featureDisplayOnlyFails", "featureDisplayHideDisabled"]) {
 			const checkbox = _preferences.find(`#${setting}`);
 			if (!checkbox) continue;
 
@@ -673,7 +673,7 @@ async function setupPreferences() {
 	}
 
 	async function saveSettings() {
-		for (let setting of ["updateNotice", "featureDisplay"]) {
+		for (let setting of ["updateNotice", "featureDisplay", "featureDisplayOnlyFails", "featureDisplayHideDisabled"]) {
 			const checkbox = _preferences.find(`#${setting}`);
 			if (!checkbox) continue;
 

--- a/extension/pages/settings/settings.js
+++ b/extension/pages/settings/settings.js
@@ -391,6 +391,7 @@ async function setupPreferences() {
 		_preferences.find(`input[name="formatTime"][value="${settings.formatting.time}"]`).checked = true;
 		_preferences.find(`input[name="themePage"][value="${settings.themes.pages}"]`).checked = true;
 		_preferences.find(`input[name="themeContainers"][value="${settings.themes.containers}"]`).checked = true;
+		_preferences.find(`input[name="featureDisplayPosition"][value="${settings.featureDisplayPosition}"]`).checked = true;
 
 		for (let type of ["pages"]) {
 			for (let page in settings[type]) {
@@ -683,6 +684,7 @@ async function setupPreferences() {
 		settings.formatting.time = _preferences.find("input[name='formatTime']:checked").value;
 		settings.themes.pages = _preferences.find("input[name='themePage']:checked").value;
 		settings.themes.containers = _preferences.find("input[name='themeContainers']:checked").value;
+		settings.featureDisplayPosition = _preferences.find("input[name='featureDisplayPosition']:checked").value;
 
 		for (let type of ["pages"]) {
 			for (let page in settings[type]) {

--- a/extension/scripts/content/global/ttGlobal.entry.js
+++ b/extension/scripts/content/global/ttGlobal.entry.js
@@ -171,7 +171,7 @@ class GlobalFeatures {
 		featureManager.new({
 			name: "Chat Font Size",
 			scope: "global",
-			enabled: settings.pages.chat.fontSize !== '12',
+			enabled: settings.pages.chat.fontSize !== 12,
 			func: feature,
 			runWhenDisabled: true,
 		});

--- a/extension/scripts/content/global/ttGlobal.entry.js
+++ b/extension/scripts/content/global/ttGlobal.entry.js
@@ -13,7 +13,7 @@ let featureManager, globalFeatures;
 
 	storageListeners.settings.push(() => {
 		globalFeatures.init();
-		featureManager.display(settings.featureDisplay);
+		featureManager.display();
 	});
 	storageListeners.userdata.push(() => {
 		globalFeatures.init();

--- a/extension/scripts/content/global/ttGlobal.entry.js
+++ b/extension/scripts/content/global/ttGlobal.entry.js
@@ -11,11 +11,11 @@ let featureManager, globalFeatures;
 
 	globalFeatures.init();
 
-	storageListeners.settings.push(function () {
+	storageListeners.settings.push(() => {
 		globalFeatures.init();
 		featureManager.display(settings.featureDisplay);
 	});
-	storageListeners.userdata.push(function () {
+	storageListeners.userdata.push(() => {
 		globalFeatures.init();
 	});
 
@@ -40,8 +40,7 @@ class GlobalFeatures {
 		// this.hideChats(); // todo
 		// this.cleanFlight(); // todo
 		this.chatFontSize();
-
-		if (hasAPIData()) this.highlightRefills();
+		this.highlightRefills(); 
 
 		requireElement("#chatRoot").then((chats) => {
 			this.blockZalgo(chats);
@@ -172,7 +171,7 @@ class GlobalFeatures {
 		featureManager.new({
 			name: "Chat Font Size",
 			scope: "global",
-			enabled: settings.pages.chat.fontSize,
+			enabled: settings.pages.chat.fontSize !== '12',
 			func: feature,
 			runWhenDisabled: true,
 		});
@@ -186,28 +185,32 @@ class GlobalFeatures {
 			name: "Highlight Energy Refill",
 			scope: "global",
 			enabled: settings.pages.sidebar.highlightEnergy,
-			func: feature_1,
+			func: feature_energy,
 			runWhenDisabled: true,
 		});
 		featureManager.new({
 			name: "Highlight Nerve Refill",
 			scope: "global",
 			enabled: settings.pages.sidebar.highlightNerve,
-			func: feature_2,
+			func: feature_nerve,
 			runWhenDisabled: true,
 		});
 
-		async function feature_1() {
-			document.documentElement.style.setProperty(
-				"--torntools-highlight-energy",
-				!userdata.refills.energy_refill_used && settings.pages.sidebar.highlightEnergy ? `#6e8820` : "#333"
-			);
+		async function feature_energy() {
+			if (hasAPIData()) {
+				document.documentElement.style.setProperty(
+					"--torntools-highlight-energy",
+					!userdata.refills.energy_refill_used && settings.pages.sidebar.highlightEnergy ? `#6e8820` : "#333"
+				);
+			} else throw 'No api data';
 		}
-		async function feature_2() {
-			document.documentElement.style.setProperty(
-				"--torntools-highlight-nerve",
-				!userdata.refills.nerve_refill_used && settings.pages.sidebar.highlightNerve ? `#6e8820` : "#333"
-			);
+		async function feature_nerve() {
+			if (hasAPIData()) {
+				document.documentElement.style.setProperty(
+					"--torntools-highlight-nerve",
+					!userdata.refills.nerve_refill_used && settings.pages.sidebar.highlightNerve ? `#6e8820` : "#333"
+				);
+			} else throw "No api data";
 		}
 	}
 	blockZalgo(chats) {

--- a/extension/scripts/content/global/ttGlobal.entry.js
+++ b/extension/scripts/content/global/ttGlobal.entry.js
@@ -13,6 +13,7 @@ let featureManager, globalFeatures;
 
 	storageListeners.settings.push(function () {
 		globalFeatures.init();
+		featureManager.display(settings.featureDisplay);
 	});
 	storageListeners.userdata.push(function () {
 		globalFeatures.init();

--- a/extension/scripts/content/home/ttHome.js
+++ b/extension/scripts/content/home/ttHome.js
@@ -13,6 +13,7 @@ let networthInterval = false;
 
 	storageListeners.settings.push(function () {
 		homeFeatures.init();
+		featureManager.display(settings.featureDisplay);
 	});
 	storageListeners.userdata.push(async (oldUserdata) => {
 		if (oldUserdata.networth && userdata.networth && oldUserdata.networth.date !== userdata.networth.date) {

--- a/extension/scripts/content/home/ttHome.js
+++ b/extension/scripts/content/home/ttHome.js
@@ -8,12 +8,9 @@ let networthInterval = false;
 	await loadDatabase();
 	console.log("TT: Home - Loading script. ");
 
-	let homeFeatures = new HomeFeatures();
-	homeFeatures.init();
+	HOME.init();
 
-	storageListeners.settings.push(() => {
-		homeFeatures.init();
-	});
+	storageListeners.settings.push(HOME.init);
 	storageListeners.userdata.push(async (oldUserdata) => {
 		if (oldUserdata.networth && userdata.networth && oldUserdata.networth.date !== userdata.networth.date) {
 			featureManager.reload("Live Networth");
@@ -23,238 +20,208 @@ let networthInterval = false;
 	console.log("TT: Home - Script loaded.");
 })();
 
-class HomeFeatures {
-	constructor() {}
+const HOME = {
+	getFeatures: () => [
+		newFeature("Live Networth", "home", settings.pages.home.networthDetails && hasAPIData() && settings.apiUsage.user.networth, LIVE_NETWORTH.showNetworth),
+		newFeature("Effective Battle Stats", "home", settings.pages.home.effectiveStats, EFFECTIVE_BATTLE_STATS.showStats),
+	],
+	init: function () {
+		// this.getFeatures().forEach(featureManager.new); // doesn't work
+		this.getFeatures().forEach((feature) => featureManager.new(feature)); // does work
 
-	init() {
-		requireContent().then(async () => {
-			this.liveNetworth();
-			this.effectiveBattleStats();
-
-			this.load();
-		});
-	}
-	load() {
+		requireContent().then(this.load);
+	},
+	load: () => {
 		featureManager.load("Live Networth");
 		featureManager.load("Effective Battle Stats");
-	}
+	},
+};
 
-	liveNetworth() {
-		featureManager.new({
-			name: "Live Networth",
-			scope: "home",
-			enabled: !!(settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()),
-			func: feature,
-			runWhenDisabled: true,
-		});
+const LIVE_NETWORTH = {
+	showNetworth: async () => {
+		if (networthInterval) {
+			clearInterval(networthInterval);
+			networthInterval = false;
+		}
 
-		async function feature() {
-			if (networthInterval) {
-				clearInterval(networthInterval);
-				networthInterval = false;
+		if (settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()) {
+			if (!userdata.networth || Date.now() - userdata.networth.date >= TO_MILLIS.MINUTES * 5) {
+				chrome.runtime.sendMessage({ action: "updateData", type: "networth" });
+				return;
 			}
 
-			if (settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()) {
-				const { content } = createContainer("Live Networth", {
-					collapsible: false,
-					showHeader: false,
-					applyRounding: false,
-					parentElement: document.find("h5=General Information").parentElement.nextElementSibling.find("ul.info-cont-wrap"),
-				});
+			const { content } = createContainer("Live Networth", {
+				collapsible: false,
+				showHeader: false,
+				applyRounding: false,
+				parentElement: document.find("h5=General Information").parentElement.nextElementSibling.find("ul.info-cont-wrap"),
+			});
 
-				if (!userdata.networth || Date.now() - userdata.networth.date >= TO_MILLIS.MINUTES * 5) {
-					chrome.runtime.sendMessage({ action: "updateData", type: "networth" });
-					return;
-				}
+			let networthRow = newRow("(Live) Networth", `$${formatNumber(userdata.networth.total)}`);
+			networthRow.style.backgroundColor = "#65c90069";
 
-				if (settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()) {
-					const { content } = createContainer("Live Networth", {
-						collapsible: false,
-						showHeader: false,
-						parentElement: document.find("h5=General Information").parentElement.nextElementSibling.find("ul.info-cont-wrap"),
-					});
+			// Networth last updated info icon
+			let infoIcon = document.newElement({
+				type: "i",
+				class: "networth-info-icon",
+				attributes: {
+					seconds: (Date.now() - userdata.networth.date) / 1000,
+					title: "Last updated " + formatTime({ milliseconds: userdata.networth.date }, { type: "ago" }),
+					style: "margin-left: 9px;",
+				},
+			});
+			networthRow.find(".desc").appendChild(infoIcon);
+			content.appendChild(networthRow);
 
-					if (!userdata.networth || Date.now() - userdata.networth.date >= TO_MILLIS.MINUTES * 5) {
-						chrome.runtime.sendMessage({ action: "updateData", type: "networth" });
-						return;
-					}
+			// Update 'last updated'
+			networthInterval = setInterval(() => {
+				let seconds = parseInt(infoIcon.getAttribute("seconds")) + 1;
 
-					let networthRow = newRow("(Live) Networth", `$${formatNumber(userdata.networth.total)}`);
-					networthRow.style.backgroundColor = "#65c90069";
+				infoIcon.setAttribute("title", `Last updated: ${formatTime({ milliseconds: Date.now() - seconds * 1000 }, { type: "ago" })}`);
+				infoIcon.setAttribute("seconds", seconds);
+			}, 1000);
 
-					// Networth last updated info icon
-					let infoIcon = document.newElement({
-						type: "i",
-						class: "networth-info-icon",
-						attributes: {
-							seconds: (Date.now() - userdata.networth.date) / 1000,
-							title: "Last updated " + formatTime({ milliseconds: userdata.networth.date }, { type: "ago" }),
-							style: "margin-left: 9px;",
-						},
-					});
-					networthRow.find(".desc").appendChild(infoIcon);
-					content.appendChild(networthRow);
+			const table = document.newElement({
+				type: "table",
+				class: "tt-networth-comparison",
+				children: [
+					document.newElement({
+						type: "tr",
+						children: ["Type", "Value", "Change"].map((value) => document.newElement({ type: "th", text: value })),
+					}),
+				],
+			});
 
-					// Update 'last updated'
-					networthInterval = setInterval(() => {
-						let seconds = parseInt(infoIcon.getAttribute("seconds")) + 1;
+			for (let type of [
+				"Cash (Wallet and Vault)",
+				"Points",
+				"Items",
+				"Bazaar",
+				"Display Case",
+				"Bank",
+				"Trade",
+				"Piggy Bank",
+				"Stock Market",
+				"Company",
+				"Bookie",
+				"Auction House",
+				"Cayman",
+				"Total",
+			]) {
+				let current, previous;
 
-						infoIcon.setAttribute("title", `Last updated: ${formatTime({ milliseconds: Date.now() - seconds * 1000 }, { type: "ago" })}`);
-						infoIcon.setAttribute("seconds", seconds);
-					}, 1000);
+				let name = type.toLowerCase().replaceAll(" ", "");
+				if (type === "Trade") name = "pending";
 
-					const table = document.newElement({
-						type: "table",
-						class: "tt-networth-comparison",
-						children: [
-							document.newElement({
-								type: "tr",
-								children: ["Type", "Value", "Change"].map((value) => document.newElement({ type: "th", text: value })),
-							}),
-						],
-					});
-
-					for (let type of [
-						"Cash (Wallet and Vault)",
-						"Points",
-						"Items",
-						"Bazaar",
-						"Display Case",
-						"Bank",
-						"Trade",
-						"Piggy Bank",
-						"Stock Market",
-						"Company",
-						"Bookie",
-						"Auction House",
-						"Cayman",
-						"Total",
-					]) {
-						let current, previous;
-
-						let name = type.toLowerCase().replaceAll(" ", "");
-						if (type === "Trade") name = "pending";
-
-						if (type.includes("Cash")) {
-							current = userdata.networth.wallet + userdata.networth.vault;
-							previous = userdata.personalstats.networthwallet + userdata.personalstats.networthvault;
-						} else if (type === "Total") {
-							current = userdata.networth.total;
-							previous = userdata.personalstats.networth;
-						} else {
-							current = userdata.networth[name];
-							previous = userdata.personalstats[`networth` + name];
-						}
-						if (current === previous) continue;
-
-						const isPositive = current > previous;
-
-						table.appendChild(
-							document.newElement({
-								type: "tr",
-								children: [
-									document.newElement({ type: "td", text: type }),
-									document.newElement({ type: "td", text: `$${formatNumber(current, { shorten: true })}` }),
-									document.newElement({
-										type: "td",
-										text: `${isPositive ? "+" : "-"}$${formatNumber(Math.abs(current - previous), { shorten: true })}`,
-										class: isPositive ? "positive" : "negative",
-									}),
-								],
-							})
-						);
-					}
-
-					content.appendChild(
-						document.newElement({
-							type: "li",
-							class: "comparison",
-							children: [
-								table,
-								document.newElement({
-									type: "div",
-									class: "tt-networth-footer",
-									text: "Networth change compared to Torn's last known Networth",
-								}),
-							],
-						})
-					);
-
-					function newRow(name, value) {
-						return document.newElement({
-							type: "li",
-							children: [
-								document.newElement({
-									type: "div",
-									class: "divider",
-									children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
-								}),
-								document.newElement({
-									type: "div",
-									class: "desc",
-									children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
-								}),
-							],
-						});
-					}
+				if (type.includes("Cash")) {
+					current = userdata.networth.wallet + userdata.networth.vault;
+					previous = userdata.personalstats.networthwallet + userdata.personalstats.networthvault;
+				} else if (type === "Total") {
+					current = userdata.networth.total;
+					previous = userdata.personalstats.networth;
 				} else {
-					removeContainer("Live Networth");
+					current = userdata.networth[name];
+					previous = userdata.personalstats[`networth` + name];
 				}
-			} else {
-				removeContainer("Live Networth");
-			}
-		}
-	}
-	effectiveBattleStats() {
-		featureManager.new({
-			name: "Effective Battle Stats",
-			scope: "home",
-			enabled: settings.pages.home.effectiveStats,
-			func: feature,
-			runWhenDisabled: true,
-		});
+				if (current === previous) continue;
 
-		async function feature() {
-			if (settings.pages.home.effectiveStats) {
-				const statsContainer = document.find("h5=Battle Stats").parentElement.nextElementSibling.find("ul.info-cont-wrap");
-				const { content } = createContainer("Effective Battle Stats", { collapsible: false, applyRounding: false, parentElement: statsContainer });
+				const isPositive = current > previous;
 
-				let effectiveTotal = 0;
-				const stats = ["Strength", "Defense", "Speed", "Dexterity"];
-				for (let i = 0; i < stats.length; i++) {
-					const base = parseInt(statsContainer.find(`li:nth-child(${i + 1}) .desc`).innerText.replace(/,/g, ""));
-					let modifier = statsContainer.find(`li:nth-child(${i + 1}) .mod`).innerText;
-					if (modifier.charAt(0) === "+") modifier = modifier = parseInt(modifier.slice(1, -1)) / 100 + 1;
-					else modifier = modifier = 1 - parseInt(modifier.slice(1, -1)) / 100;
-					const effective = (base * modifier).dropDecimals();
-
-					effectiveTotal += effective;
-					content.appendChild(await newRow(stats[i], formatNumber(effective)));
-				}
-
-				content.appendChild(await newRow("Total", formatNumber(effectiveTotal, false)));
-
-				async function newRow(name, value) {
-					return document.newElement({
-						type: "li",
+				table.appendChild(
+					document.newElement({
+						type: "tr",
 						children: [
+							document.newElement({ type: "td", text: type }),
+							document.newElement({ type: "td", text: `$${formatNumber(current, { shorten: true })}` }),
 							document.newElement({
-								type: "div",
-								class: "divider",
-								children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
-							}),
-							document.newElement({
-								type: "div",
-								class: "desc",
-								style: { width: (await checkMobile()) ? "180px" : "184px" },
-								children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
+								type: "td",
+								text: `${isPositive ? "+" : "-"}$${formatNumber(Math.abs(current - previous), { shorten: true })}`,
+								class: isPositive ? "positive" : "negative",
 							}),
 						],
-					});
-				}
-			} else {
-				removeContainer("Effective Battle Stats");
+					})
+				);
 			}
+
+			content.appendChild(
+				document.newElement({
+					type: "li",
+					class: "comparison",
+					children: [
+						table,
+						document.newElement({
+							type: "div",
+							class: "tt-networth-footer",
+							text: "Networth change compared to Torn's last known Networth",
+						}),
+					],
+				})
+			);
+
+			function newRow(name, value) {
+				return document.newElement({
+					type: "li",
+					children: [
+						document.newElement({
+							type: "div",
+							class: "divider",
+							children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
+						}),
+						document.newElement({
+							type: "div",
+							class: "desc",
+							children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
+						}),
+					],
+				});
+			}
+		} else {
+			removeContainer("Live Networth");
 		}
-	}
-}
+	},
+};
+
+const EFFECTIVE_BATTLE_STATS = {
+	showStats: async () => {
+		if (settings.pages.home.effectiveStats) {
+			const statsContainer = document.find("h5=Battle Stats").parentElement.nextElementSibling.find("ul.info-cont-wrap");
+			const { content } = createContainer("Effective Battle Stats", { collapsible: false, applyRounding: false, parentElement: statsContainer });
+
+			let effectiveTotal = 0;
+			const stats = ["Strength", "Defense", "Speed", "Dexterity"];
+			for (let i = 0; i < stats.length; i++) {
+				const base = parseInt(statsContainer.find(`li:nth-child(${i + 1}) .desc`).innerText.replace(/,/g, ""));
+				let modifier = statsContainer.find(`li:nth-child(${i + 1}) .mod`).innerText;
+				if (modifier.charAt(0) === "+") modifier = modifier = parseInt(modifier.slice(1, -1)) / 100 + 1;
+				else modifier = modifier = 1 - parseInt(modifier.slice(1, -1)) / 100;
+				const effective = (base * modifier).dropDecimals();
+
+				effectiveTotal += effective;
+				content.appendChild(await newRow(stats[i], formatNumber(effective)));
+			}
+
+			content.appendChild(await newRow("Total", formatNumber(effectiveTotal, false)));
+
+			async function newRow(name, value) {
+				return document.newElement({
+					type: "li",
+					children: [
+						document.newElement({
+							type: "div",
+							class: "divider",
+							children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
+						}),
+						document.newElement({
+							type: "div",
+							class: "desc",
+							style: { width: (await checkMobile()) ? "180px" : "184px" },
+							children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
+						}),
+					],
+				});
+			}
+		} else {
+			removeContainer("Effective Battle Stats");
+		}
+	},
+};

--- a/extension/scripts/content/home/ttHome.js
+++ b/extension/scripts/content/home/ttHome.js
@@ -26,7 +26,6 @@ const HOME = {
 		newFeature("Effective Battle Stats", "home", settings.pages.home.effectiveStats, EFFECTIVE_BATTLE_STATS.showStats),
 	],
 	init: function () {
-		// this.getFeatures().forEach(featureManager.new); // doesn't work
 		this.getFeatures().forEach((feature) => featureManager.new(feature)); // does work
 
 		requireContent().then(this.load);

--- a/extension/scripts/content/home/ttHome.js
+++ b/extension/scripts/content/home/ttHome.js
@@ -1,7 +1,6 @@
 "use strict";
 
 let networthInterval = false;
-let featureManager = new FeatureManager();
 
 (async () => {
 	if (isFlying() || isAbroad()) return;
@@ -9,9 +8,12 @@ let featureManager = new FeatureManager();
 	await loadDatabase();
 	console.log("TT: Home - Loading script. ");
 
-	loadHome();
+	let homeFeatures = new HomeFeatures();
+	homeFeatures.init();
 
-	storageListeners.settings.push(loadHome);
+	storageListeners.settings.push(function () {
+		homeFeatures.init();
+	});
 	storageListeners.userdata.push(async (oldUserdata) => {
 		if (oldUserdata.networth && userdata.networth && oldUserdata.networth.date !== userdata.networth.date) {
 			featureManager.reload("Live Networth");
@@ -21,216 +23,238 @@ let featureManager = new FeatureManager();
 	console.log("TT: Home - Script loaded.");
 })();
 
-function loadHome() {
-	requireContent().then(async () => {
-		featureManager.clear();
-		featureManager.load({
-			name: "Live Networth",
-			enabled: !!(settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()),
-			func: displayNetworth,
-			runWhenDisabled: true,
-		});
-		featureManager.load({
-			name: "Effective Battle Stats",
-			enabled: settings.pages.home.effectiveStats,
-			func: displayEffectiveBattleStats,
-			runWhenDisabled: true,
-		});
-	});
-}
+class HomeFeatures {
+	constructor() {}
 
-async function displayNetworth() {
-	if (networthInterval) {
-		clearInterval(networthInterval);
-		networthInterval = false;
+	init() {
+		requireContent().then(async () => {
+			this.liveNetworth();
+			this.effectiveBattleStats();
+
+			this.load();
+		});
+	}
+	load() {
+		featureManager.load("Live Networth");
+		featureManager.load("Effective Battle Stats");
 	}
 
-	if (settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()) {
-		const { content } = createContainer("Live Networth", {
-			collapsible: false,
-			showHeader: false,
-			applyRounding: false,
-			parentElement: document.find("h5=General Information").parentElement.nextElementSibling.find("ul.info-cont-wrap"),
+	liveNetworth() {
+		featureManager.new({
+			name: "Live Networth",
+			scope: "home",
+			enabled: !!(settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()),
+			func: feature,
+			runWhenDisabled: true,
 		});
 
-		if (!userdata.networth || Date.now() - userdata.networth.date >= TO_MILLIS.MINUTES * 5) {
-			chrome.runtime.sendMessage({ action: "updateData", type: "networth" });
-			return;
-		}
-
-		if (settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()) {
-			const { content } = createContainer("Live Networth", {
-				collapsible: false,
-				showHeader: false,
-				parentElement: document.find("h5=General Information").parentElement.nextElementSibling.find("ul.info-cont-wrap"),
-			});
-
-			if (!userdata.networth || Date.now() - userdata.networth.date >= TO_MILLIS.MINUTES * 5) {
-				chrome.runtime.sendMessage({ action: "updateData", type: "networth" });
-				return;
+		async function feature() {
+			if (networthInterval) {
+				clearInterval(networthInterval);
+				networthInterval = false;
 			}
 
-			let networthRow = newRow("(Live) Networth", `$${formatNumber(userdata.networth.total)}`);
-			networthRow.style.backgroundColor = "#65c90069";
+			if (settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()) {
+				const { content } = createContainer("Live Networth", {
+					collapsible: false,
+					showHeader: false,
+					applyRounding: false,
+					parentElement: document.find("h5=General Information").parentElement.nextElementSibling.find("ul.info-cont-wrap"),
+				});
 
-			// Networth last updated info icon
-			let infoIcon = document.newElement({
-				type: "i",
-				class: "networth-info-icon",
-				attributes: {
-					seconds: (Date.now() - userdata.networth.date) / 1000,
-					title: "Last updated " + formatTime({ milliseconds: userdata.networth.date }, { type: "ago" }),
-					style: "margin-left: 9px;",
-				},
-			});
-			networthRow.find(".desc").appendChild(infoIcon);
-			content.appendChild(networthRow);
-
-			// Update 'last updated'
-			networthInterval = setInterval(() => {
-				let seconds = parseInt(infoIcon.getAttribute("seconds")) + 1;
-
-				infoIcon.setAttribute("title", `Last updated: ${formatTime({ milliseconds: Date.now() - seconds * 1000 }, { type: "ago" })}`);
-				infoIcon.setAttribute("seconds", seconds);
-			}, 1000);
-
-			const table = document.newElement({
-				type: "table",
-				class: "tt-networth-comparison",
-				children: [
-					document.newElement({
-						type: "tr",
-						children: ["Type", "Value", "Change"].map((value) => document.newElement({ type: "th", text: value })),
-					}),
-				],
-			});
-
-			for (let type of [
-				"Cash (Wallet and Vault)",
-				"Points",
-				"Items",
-				"Bazaar",
-				"Display Case",
-				"Bank",
-				"Trade",
-				"Piggy Bank",
-				"Stock Market",
-				"Company",
-				"Bookie",
-				"Auction House",
-				"Cayman",
-				"Total",
-			]) {
-				let current, previous;
-
-				let name = type.toLowerCase().replaceAll(" ", "");
-				if (type === "Trade") name = "pending";
-
-				if (type.includes("Cash")) {
-					current = userdata.networth.wallet + userdata.networth.vault;
-					previous = userdata.personalstats.networthwallet + userdata.personalstats.networthvault;
-				} else if (type === "Total") {
-					current = userdata.networth.total;
-					previous = userdata.personalstats.networth;
-				} else {
-					current = userdata.networth[name];
-					previous = userdata.personalstats[`networth` + name];
+				if (!userdata.networth || Date.now() - userdata.networth.date >= TO_MILLIS.MINUTES * 5) {
+					chrome.runtime.sendMessage({ action: "updateData", type: "networth" });
+					return;
 				}
-				if (current === previous) continue;
 
-				const isPositive = current > previous;
+				if (settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()) {
+					const { content } = createContainer("Live Networth", {
+						collapsible: false,
+						showHeader: false,
+						parentElement: document.find("h5=General Information").parentElement.nextElementSibling.find("ul.info-cont-wrap"),
+					});
 
-				table.appendChild(
-					document.newElement({
-						type: "tr",
+					if (!userdata.networth || Date.now() - userdata.networth.date >= TO_MILLIS.MINUTES * 5) {
+						chrome.runtime.sendMessage({ action: "updateData", type: "networth" });
+						return;
+					}
+
+					let networthRow = newRow("(Live) Networth", `$${formatNumber(userdata.networth.total)}`);
+					networthRow.style.backgroundColor = "#65c90069";
+
+					// Networth last updated info icon
+					let infoIcon = document.newElement({
+						type: "i",
+						class: "networth-info-icon",
+						attributes: {
+							seconds: (Date.now() - userdata.networth.date) / 1000,
+							title: "Last updated " + formatTime({ milliseconds: userdata.networth.date }, { type: "ago" }),
+							style: "margin-left: 9px;",
+						},
+					});
+					networthRow.find(".desc").appendChild(infoIcon);
+					content.appendChild(networthRow);
+
+					// Update 'last updated'
+					networthInterval = setInterval(() => {
+						let seconds = parseInt(infoIcon.getAttribute("seconds")) + 1;
+
+						infoIcon.setAttribute("title", `Last updated: ${formatTime({ milliseconds: Date.now() - seconds * 1000 }, { type: "ago" })}`);
+						infoIcon.setAttribute("seconds", seconds);
+					}, 1000);
+
+					const table = document.newElement({
+						type: "table",
+						class: "tt-networth-comparison",
 						children: [
-							document.newElement({ type: "td", text: type }),
-							document.newElement({ type: "td", text: `$${formatNumber(current, { shorten: true })}` }),
 							document.newElement({
-								type: "td",
-								text: `${isPositive ? "+" : "-"}$${formatNumber(Math.abs(current - previous), { shorten: true })}`,
-								class: isPositive ? "positive" : "negative",
+								type: "tr",
+								children: ["Type", "Value", "Change"].map((value) => document.newElement({ type: "th", text: value })),
 							}),
 						],
-					})
-				);
-			}
+					});
 
-			content.appendChild(
-				document.newElement({
-					type: "li",
-					class: "comparison",
-					children: [
-						table,
-						document.newElement({ type: "div", class: "tt-networth-footer", text: "Networth change compared to Torn's last known Networth" }),
-					],
-				})
-			);
+					for (let type of [
+						"Cash (Wallet and Vault)",
+						"Points",
+						"Items",
+						"Bazaar",
+						"Display Case",
+						"Bank",
+						"Trade",
+						"Piggy Bank",
+						"Stock Market",
+						"Company",
+						"Bookie",
+						"Auction House",
+						"Cayman",
+						"Total",
+					]) {
+						let current, previous;
 
-			function newRow(name, value) {
-				return document.newElement({
-					type: "li",
-					children: [
+						let name = type.toLowerCase().replaceAll(" ", "");
+						if (type === "Trade") name = "pending";
+
+						if (type.includes("Cash")) {
+							current = userdata.networth.wallet + userdata.networth.vault;
+							previous = userdata.personalstats.networthwallet + userdata.personalstats.networthvault;
+						} else if (type === "Total") {
+							current = userdata.networth.total;
+							previous = userdata.personalstats.networth;
+						} else {
+							current = userdata.networth[name];
+							previous = userdata.personalstats[`networth` + name];
+						}
+						if (current === previous) continue;
+
+						const isPositive = current > previous;
+
+						table.appendChild(
+							document.newElement({
+								type: "tr",
+								children: [
+									document.newElement({ type: "td", text: type }),
+									document.newElement({ type: "td", text: `$${formatNumber(current, { shorten: true })}` }),
+									document.newElement({
+										type: "td",
+										text: `${isPositive ? "+" : "-"}$${formatNumber(Math.abs(current - previous), { shorten: true })}`,
+										class: isPositive ? "positive" : "negative",
+									}),
+								],
+							})
+						);
+					}
+
+					content.appendChild(
 						document.newElement({
-							type: "div",
-							class: "divider",
-							children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
-						}),
-						document.newElement({
-							type: "div",
-							class: "desc",
-							children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
-						}),
-					],
-				});
+							type: "li",
+							class: "comparison",
+							children: [
+								table,
+								document.newElement({
+									type: "div",
+									class: "tt-networth-footer",
+									text: "Networth change compared to Torn's last known Networth",
+								}),
+							],
+						})
+					);
+
+					function newRow(name, value) {
+						return document.newElement({
+							type: "li",
+							children: [
+								document.newElement({
+									type: "div",
+									class: "divider",
+									children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
+								}),
+								document.newElement({
+									type: "div",
+									class: "desc",
+									children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
+								}),
+							],
+						});
+					}
+				} else {
+					removeContainer("Live Networth");
+				}
+			} else {
+				removeContainer("Live Networth");
 			}
-		} else {
-			removeContainer("Live Networth");
 		}
-	} else {
-		removeContainer("Live Networth");
 	}
-}
+	effectiveBattleStats() {
+		featureManager.new({
+			name: "Effective Battle Stats",
+			scope: "home",
+			enabled: settings.pages.home.effectiveStats,
+			func: feature,
+			runWhenDisabled: true,
+		});
 
-async function displayEffectiveBattleStats() {
-	if (settings.pages.home.effectiveStats) {
-		const statsContainer = document.find("h5=Battle Stats").parentElement.nextElementSibling.find("ul.info-cont-wrap");
-		const { content } = createContainer("Effective Battle Stats", { collapsible: false, applyRounding: false, parentElement: statsContainer });
+		async function feature() {
+			if (settings.pages.home.effectiveStats) {
+				const statsContainer = document.find("h5=Battle Stats").parentElement.nextElementSibling.find("ul.info-cont-wrap");
+				const { content } = createContainer("Effective Battle Stats", { collapsible: false, applyRounding: false, parentElement: statsContainer });
 
-		let effectiveTotal = 0;
-		const stats = ["Strength", "Defense", "Speed", "Dexterity"];
-		for (let i = 0; i < stats.length; i++) {
-			const base = parseInt(statsContainer.find(`li:nth-child(${i + 1}) .desc`).innerText.replace(/,/g, ""));
-			let modifier = statsContainer.find(`li:nth-child(${i + 1}) .mod`).innerText;
-			if (modifier.charAt(0) === "+") modifier = modifier = parseInt(modifier.slice(1, -1)) / 100 + 1;
-			else modifier = modifier = 1 - parseInt(modifier.slice(1, -1)) / 100;
-			const effective = (base * modifier).dropDecimals();
+				let effectiveTotal = 0;
+				const stats = ["Strength", "Defense", "Speed", "Dexterity"];
+				for (let i = 0; i < stats.length; i++) {
+					const base = parseInt(statsContainer.find(`li:nth-child(${i + 1}) .desc`).innerText.replace(/,/g, ""));
+					let modifier = statsContainer.find(`li:nth-child(${i + 1}) .mod`).innerText;
+					if (modifier.charAt(0) === "+") modifier = modifier = parseInt(modifier.slice(1, -1)) / 100 + 1;
+					else modifier = modifier = 1 - parseInt(modifier.slice(1, -1)) / 100;
+					const effective = (base * modifier).dropDecimals();
 
-			effectiveTotal += effective;
-			content.appendChild(await newRow(stats[i], formatNumber(effective)));
+					effectiveTotal += effective;
+					content.appendChild(await newRow(stats[i], formatNumber(effective)));
+				}
+
+				content.appendChild(await newRow("Total", formatNumber(effectiveTotal, false)));
+
+				async function newRow(name, value) {
+					return document.newElement({
+						type: "li",
+						children: [
+							document.newElement({
+								type: "div",
+								class: "divider",
+								children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
+							}),
+							document.newElement({
+								type: "div",
+								class: "desc",
+								style: { width: (await checkMobile()) ? "180px" : "184px" },
+								children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
+							}),
+						],
+					});
+				}
+			} else {
+				removeContainer("Effective Battle Stats");
+			}
 		}
-
-		content.appendChild(await newRow("Total", formatNumber(effectiveTotal, false)));
-
-		async function newRow(name, value) {
-			return document.newElement({
-				type: "li",
-				children: [
-					document.newElement({
-						type: "div",
-						class: "divider",
-						children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
-					}),
-					document.newElement({
-						type: "div",
-						class: "desc",
-						style: { width: (await checkMobile()) ? "180px" : "184px" },
-						children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
-					}),
-				],
-			});
-		}
-	} else {
-		removeContainer("Effective Battle Stats");
 	}
 }

--- a/extension/scripts/content/home/ttHome.js
+++ b/extension/scripts/content/home/ttHome.js
@@ -1,6 +1,7 @@
 "use strict";
 
 let networthInterval = false;
+let featureManager = new FeatureManager();
 
 (async () => {
 	if (isFlying() || isAbroad()) return;
@@ -8,22 +9,33 @@ let networthInterval = false;
 	await loadDatabase();
 	console.log("TT: Home - Loading script. ");
 
+	loadHome();
+
 	storageListeners.settings.push(loadHome);
 	storageListeners.userdata.push(async (oldUserdata) => {
 		if (oldUserdata.networth && userdata.networth && oldUserdata.networth.date !== userdata.networth.date) {
-			await displayNetworth();
+			featureManager.reload('Live Networth');
 		}
 	});
-
-	loadHome();
 
 	console.log("TT: Home - Script loaded.");
 })();
 
 function loadHome() {
 	requireContent().then(async () => {
-		await displayNetworth().catch((error) => console.error("Couldn't load the live networth.", error));
-		await displayEffectiveBattleStats().catch((error) => console.error("Couldn't load the effective battle stats.", error));
+		featureManager.clear();
+		featureManager.load({
+			name: 'Live Networth',
+			enabled: !!(settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()),
+			func: displayNetworth,
+			runWhenDisabled: true
+		});
+		featureManager.load({
+			name: 'Effective Battle Stats',
+			enabled: settings.pages.home.effectiveStats,
+			func: displayEffectiveBattleStats,
+			runWhenDisabled: true
+		});
 	});
 }
 
@@ -46,119 +58,134 @@ async function displayNetworth() {
 			return;
 		}
 
-		let networthRow = newRow("(Live) Networth", `$${formatNumber(userdata.networth.total)}`);
-		networthRow.style.backgroundColor = "#65c90069";
+		if (settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()) {
+			const { content } = createContainer("Live Networth", {
+				collapsible: false,
+				showHeader: false,
+				parentElement: document.find("h5=General Information").parentElement.nextElementSibling.find("ul.info-cont-wrap"),
+			});
 
-		// Networth last updated info icon
-		let infoIcon = document.newElement({
-			type: "i",
-			class: "networth-info-icon",
-			attributes: {
-				seconds: (Date.now() - userdata.networth.date) / 1000,
-				title: "Last updated " + formatTime({ milliseconds: userdata.networth.date }, { type: "ago" }),
-				style: "margin-left: 9px;",
-			},
-		});
-		networthRow.find(".desc").appendChild(infoIcon);
-		content.appendChild(networthRow);
-
-		// Update 'last updated'
-		networthInterval = setInterval(() => {
-			let seconds = parseInt(infoIcon.getAttribute("seconds")) + 1;
-
-			infoIcon.setAttribute("title", `Last updated: ${formatTime({ milliseconds: Date.now() - seconds * 1000 }, { type: "ago" })}`);
-			infoIcon.setAttribute("seconds", `${seconds}`);
-		}, 1000);
-
-		const table = document.newElement({
-			type: "table",
-			class: "tt-networth-comparison",
-			children: [
-				document.newElement({
-					type: "tr",
-					children: ["Type", "Value", "Change"].map((value) => document.newElement({ type: "th", text: value })),
-				}),
-			],
-		});
-
-		for (let type of [
-			"Cash (Wallet and Vault)",
-			"Points",
-			"Items",
-			"Bazaar",
-			"Display Case",
-			"Bank",
-			"Trade",
-			"Piggy Bank",
-			"Stock Market",
-			"Company",
-			"Bookie",
-			"Auction House",
-			"Cayman",
-			"Total",
-		]) {
-			let current, previous;
-
-			let name = type.toLowerCase().replaceAll(" ", "");
-			if (type === "Trade") name = "pending";
-
-			if (type.includes("Cash")) {
-				current = userdata.networth.wallet + userdata.networth.vault;
-				previous = userdata.personalstats.networthwallet + userdata.personalstats.networthvault;
-			} else if (type === "Total") {
-				current = userdata.networth.total;
-				previous = userdata.personalstats.networth;
-			} else {
-				current = userdata.networth[name];
-				previous = userdata.personalstats[`networth` + name];
+			if (!userdata.networth || Date.now() - userdata.networth.date >= TO_MILLIS.MINUTES * 5) {
+				chrome.runtime.sendMessage({ action: "updateData", type: "networth" });
+				return;
 			}
-			if (current === previous) continue;
 
-			const isPositive = current > previous;
+			let networthRow = newRow("(Live) Networth", `$${formatNumber(userdata.networth.total)}`);
+			networthRow.style.backgroundColor = "#65c90069";
 
-			table.appendChild(
-				document.newElement({
-					type: "tr",
-					children: [
-						document.newElement({ type: "td", text: type }),
-						document.newElement({ type: "td", text: `$${formatNumber(current, { shorten: true })}` }),
-						document.newElement({
-							type: "td",
-							text: `${isPositive ? "+" : "-"}$${formatNumber(Math.abs(current - previous), { shorten: true })}`,
-							class: isPositive ? "positive" : "negative",
-						}),
-					],
-				})
-			);
-		}
+			// Networth last updated info icon
+			let infoIcon = document.newElement({
+				type: "i",
+				class: "networth-info-icon",
+				attributes: {
+					seconds: (Date.now() - userdata.networth.date) / 1000,
+					title: "Last updated " + formatTime({ milliseconds: userdata.networth.date }, { type: "ago" }),
+					style: "margin-left: 9px;",
+				},
+			});
+			networthRow.find(".desc").appendChild(infoIcon);
+			content.appendChild(networthRow);
 
-		content.appendChild(
-			document.newElement({
-				type: "li",
-				class: "comparison",
-				children: [
-					table,
-					document.newElement({ type: "div", class: "tt-networth-footer", text: "Networth change compared to Torn's last known Networth" }),
-				],
-			})
-		);
+			// Update 'last updated'
+			networthInterval = setInterval(() => {
+				let seconds = parseInt(infoIcon.getAttribute("seconds")) + 1;
 
-		function newRow(name, value) {
-			return document.newElement({
-				type: "li",
+				infoIcon.setAttribute("title", `Last updated: ${formatTime({ milliseconds: Date.now() - seconds * 1000 }, { type: "ago" })}`);
+				infoIcon.setAttribute("seconds", seconds);
+			}, 1000);
+
+			const table = document.newElement({
+				type: "table",
+				class: "tt-networth-comparison",
 				children: [
 					document.newElement({
-						type: "div",
-						class: "divider",
-						children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
-					}),
-					document.newElement({
-						type: "div",
-						class: "desc",
-						children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
+						type: "tr",
+						children: ["Type", "Value", "Change"].map((value) => document.newElement({ type: "th", text: value })),
 					}),
 				],
 			});
+
+			for (let type of [
+				"Cash (Wallet and Vault)",
+				"Points",
+				"Items",
+				"Bazaar",
+				"Display Case",
+				"Bank",
+				"Trade",
+				"Piggy Bank",
+				"Stock Market",
+				"Company",
+				"Bookie",
+				"Auction House",
+				"Cayman",
+				"Total",
+			]) {
+				let current, previous;
+
+				let name = type.toLowerCase().replaceAll(" ", "");
+				if (type === "Trade") name = "pending";
+
+				if (type.includes("Cash")) {
+					current = userdata.networth.wallet + userdata.networth.vault;
+					previous = userdata.personalstats.networthwallet + userdata.personalstats.networthvault;
+				} else if (type === "Total") {
+					current = userdata.networth.total;
+					previous = userdata.personalstats.networth;
+				} else {
+					current = userdata.networth[name];
+					previous = userdata.personalstats[`networth` + name];
+				}
+				if (current === previous) continue;
+
+				const isPositive = current > previous;
+
+				table.appendChild(
+					document.newElement({
+						type: "tr",
+						children: [
+							document.newElement({ type: "td", text: type }),
+							document.newElement({ type: "td", text: `$${formatNumber(current, { shorten: true })}` }),
+							document.newElement({
+								type: "td",
+								text: `${isPositive ? "+" : "-"}$${formatNumber(Math.abs(current - previous), { shorten: true })}`,
+								class: isPositive ? "positive" : "negative",
+							}),
+						],
+					})
+				);
+			}
+
+			content.appendChild(
+				document.newElement({
+					type: "li",
+					class: "comparison",
+					children: [
+						table,
+						document.newElement({ type: "div", class: "tt-networth-footer", text: "Networth change compared to Torn's last known Networth" }),
+					],
+				})
+			);
+
+			function newRow(name, value) {
+				return document.newElement({
+					type: "li",
+					children: [
+						document.newElement({
+							type: "div",
+							class: "divider",
+							children: [document.newElement({ type: "span", text: name, style: { backgroundColor: "transparent" } })],
+						}),
+						document.newElement({
+							type: "div",
+							class: "desc",
+							children: [document.newElement({ type: "span", text: value, style: { paddingLeft: "3px" } })],
+						}),
+					],
+				});
+			}
+		} else {
+			removeContainer("Live Networth");
 		}
 	} else {
 		removeContainer("Live Networth");

--- a/extension/scripts/content/home/ttHome.js
+++ b/extension/scripts/content/home/ttHome.js
@@ -14,7 +14,7 @@ let featureManager = new FeatureManager();
 	storageListeners.settings.push(loadHome);
 	storageListeners.userdata.push(async (oldUserdata) => {
 		if (oldUserdata.networth && userdata.networth && oldUserdata.networth.date !== userdata.networth.date) {
-			featureManager.reload('Live Networth');
+			featureManager.reload("Live Networth");
 		}
 	});
 
@@ -25,16 +25,16 @@ function loadHome() {
 	requireContent().then(async () => {
 		featureManager.clear();
 		featureManager.load({
-			name: 'Live Networth',
+			name: "Live Networth",
 			enabled: !!(settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()),
 			func: displayNetworth,
-			runWhenDisabled: true
+			runWhenDisabled: true,
 		});
 		featureManager.load({
-			name: 'Effective Battle Stats',
+			name: "Effective Battle Stats",
 			enabled: settings.pages.home.effectiveStats,
 			func: displayEffectiveBattleStats,
-			runWhenDisabled: true
+			runWhenDisabled: true,
 		});
 	});
 }

--- a/extension/scripts/content/home/ttHome.js
+++ b/extension/scripts/content/home/ttHome.js
@@ -11,9 +11,8 @@ let networthInterval = false;
 	let homeFeatures = new HomeFeatures();
 	homeFeatures.init();
 
-	storageListeners.settings.push(function () {
+	storageListeners.settings.push(() => {
 		homeFeatures.init();
-		featureManager.display(settings.featureDisplay);
 	});
 	storageListeners.userdata.push(async (oldUserdata) => {
 		if (oldUserdata.networth && userdata.networth && oldUserdata.networth.date !== userdata.networth.date) {

--- a/extension/scripts/content/items/ttItems.js
+++ b/extension/scripts/content/items/ttItems.js
@@ -6,552 +6,607 @@ let pendingActions = {};
 	await loadDatabase();
 	console.log("TT: Items - Loading script. ");
 
-	storageListeners.settings.push(loadItems);
-	loadItems();
+	let itemsFeatures = new ItemsFeatures();
+	itemsFeatures.init();
 
-	loadItemsOnce();
+	storageListeners.settings.push(function () {
+		itemsFeatures.init();
+	});
+
+	itemsFeatures.loadItemsOnce();
 
 	console.log("TT: Items - Script loaded.");
 })();
 
-function loadItems() {
-	requireContent().then(() => {
-		loadQuickItems().catch((error) => console.error("Couldn't load the quick items.", error));
-	});
-	requireItemsLoaded().then(() => {
-		initializeItems();
-	});
-}
+class ItemsFeatures {
+	constructor() {}
 
-function loadItemsOnce() {
-	document.addEventListener("click", (event) => {
-		if (event.target.classList.contains("close-act")) {
-			const responseWrap = findParent(event.target, { class: "response-wrap" });
+	init() {
+		requireContent().then(() => {
+			this.quickItems();
 
-			if (responseWrap) responseWrap.style.display = "none";
-		}
-	});
-	setInterval(() => {
-		for (let timer of document.findAll(".counter-wrap.tt-modified")) {
-			let secondsLeft;
-			if ("secondsLeft" in timer.dataset) secondsLeft = parseInt(timer.dataset.secondsLeft);
-			else secondsLeft = parseInt(timer.dataset.time);
-			secondsLeft--;
-
-			timer.innerText = formatTime({ seconds: secondsLeft }, { type: "timer" });
-
-			timer.dataset.secondsLeft = `${secondsLeft}`;
-		}
-	}, 1000);
-
-	addXHRListener((event) => {
-		const { page, json, xhr } = event.detail;
-
-		if (page === "item" && json) {
-			const params = new URLSearchParams(xhr.requestBody);
-			const step = params.get("step");
-
-			if (step === "useItem") {
-				if (!json.success) return;
-
-				if (params.get("step") !== "useItem") return;
-				if (params.has("fac") && params.get("fac") !== "0") return;
-
-				if (json.items) {
-					for (const item of json.items.itemAppear) {
-						updateItemAmount(parseInt(item.ID), parseInt(item.qty));
-					}
-					for (const item of json.items.itemDisappear) {
-						updateItemAmount(parseInt(item.ID), -parseInt(item.qty));
-					}
-				} else {
-					updateItemAmount(parseInt(params.get("itemID")), -1);
-				}
-			} else if (step === "sendItemAction") {
-				if (!json.success) return;
-
-				const actionId = json.confirm ? json.itemID : params.get("XID");
-				const item = json.confirm ? params.get("itemID") : pendingActions[actionId].item;
-				const amount = json.amount;
-
-				if (json.confirm) pendingActions[actionId] = { item };
-				else {
-					delete pendingActions[actionId];
-
-					updateItemAmount(item, -amount);
-				}
-			} else if (step === "getCategoryList" || step === "getNotAllItemsListWithoutGroups" || step === "getItemsListByItemId") {
-				const tab = document.find("ul.items-cont.tab-menu-cont[style='display: block;'], ul.items-cont.tab-menu-cont:not([style])");
-				if (!tab) return;
-
-				new MutationObserver((mutations, observer) => {
-					if (document.find("li.ajax-item-loader")) return;
-
-					highlightBloodBags().catch((error) => console.error("Couldn't highlight the correct blood bags.", error));
-					showItemValues().catch((error) => console.error("Couldn't show the item values.", error));
-					showItemMarketIcons().catch((error) => console.error("Couldn't show the market icons.", error));
-
-					observer.disconnect();
-				}).observe(tab, { subtree: true, childList: true });
-			}
-		} else if (page === "inventory" && json) {
-			const params = new URLSearchParams(xhr.requestBody);
-			const step = params.get("step");
-
-			if (step === "info") {
-				showDrugDetails(parseInt(params.get("itemID"))).catch((error) => console.error("Couldn't show drug details.", error));
-			}
-		}
-	});
-
-	requireItemsLoaded().then(() => {
-		for (let icon of document.findAll("ul[role=tablist] li:not(.no-items):not(.m-show):not(.hide)")) {
-			icon.addEventListener("click", () => requireItemsLoaded().then(initializeItems));
-		}
-	});
-}
-
-function requireItemsLoaded() {
-	return requireElement(".items-cont[aria-expanded=true] > li > .title-wrap");
-}
-
-function initializeItems() {
-	setupQuickDragListeners().catch((error) => console.error("Couldn't make the items draggable for quick items.", error));
-	highlightBloodBags().catch((error) => console.error("Couldn't highlight the correct blood bags.", error));
-	showItemValues().catch((error) => console.error("Couldn't show the item values.", error));
-	showItemMarketIcons().catch((error) => console.error("Couldn't show the market icons.", error));
-}
-
-async function loadQuickItems() {
-	if (settings.pages.items.quickItems) {
-		const { content, options } = createContainer("Quick Items", {
-			nextElement: document.find(".equipped-items-wrap"),
-			spacer: true,
-			allowDragging: true,
+			featureManager.load("Quick Items");
 		});
-		content.appendChild(document.newElement({ type: "div", class: "inner-content" }));
-		content.appendChild(document.newElement({ type: "div", class: "response-wrap" }));
-		options.appendChild(
-			document.newElement({
-				type: "div",
-				class: "option",
-				id: "edit-items-button",
-				children: [document.newElement({ type: "i", class: "fas fa-plus" }), " Add"],
-				events: {
-					click: (event) => {
-						event.stopPropagation();
+		this.requireItemsLoaded().then(() => {
+			this.setupQuickDragListeners().catch((error) => console.error("Couldn't make the items draggable for quick items.", error));
 
-						document.find("ul.items-cont[aria-expanded='true']").classList.toggle("tt-overlay-item");
-						options.find("#edit-items-button").classList.toggle("tt-overlay-item");
-						if (document.find(".tt-overlay").classList.toggle("hidden")) {
-							for (let item of document.findAll("ul.items-cont[aria-expanded='true'] > li")) {
-								if (!allowQuickItem(item.getAttribute("data-category"))) continue;
+			this.highlightBloodbags();
+			this.itemValues();
+			this.itemMarketIcons();
+			this.drugDetails();
 
-								item.removeEventListener("click", onItemClickQuickEdit);
-							}
-						} else {
-							for (let item of document.findAll("ul.items-cont[aria-expanded='true'] > li")) {
-								if (!allowQuickItem(item.getAttribute("data-category"))) continue;
+			featureManager.load("Highlight Bloodbags");
+			featureManager.load("Item Values");
+			featureManager.load("Item Market Icons");
+			featureManager.load("Drug Details");
+		});
+	}
 
-								item.addEventListener("click", onItemClickQuickEdit);
-							}
+	// Page Features
+	quickItems() {
+		// feature function has a 'this' call in it
+		let feature = async () => {
+			if (settings.pages.items.quickItems) {
+				const { content, options } = createContainer("Quick Items", {
+					nextElement: document.find(".equipped-items-wrap"),
+					spacer: true,
+					allowDragging: true,
+				});
+				content.appendChild(document.newElement({ type: "div", class: "inner-content" }));
+				content.appendChild(document.newElement({ type: "div", class: "response-wrap" }));
+				options.appendChild(
+					document.newElement({
+						type: "div",
+						class: "option",
+						id: "edit-items-button",
+						children: [document.newElement({ type: "i", class: "fas fa-plus" }), " Add"],
+						events: {
+							click: (event) => {
+								event.stopPropagation();
+
+								document.find("ul.items-cont[aria-expanded='true']").classList.toggle("tt-overlay-item");
+								options.find("#edit-items-button").classList.toggle("tt-overlay-item");
+								if (document.find(".tt-overlay").classList.toggle("hidden")) {
+									for (let item of document.findAll("ul.items-cont[aria-expanded='true'] > li")) {
+										if (!this.allowQuickItem(item.getAttribute("data-category"))) continue;
+
+										item.removeEventListener("click", this.onItemClickQuickEdit);
+									}
+								} else {
+									for (let item of document.findAll("ul.items-cont[aria-expanded='true'] > li")) {
+										if (!this.allowQuickItem(item.getAttribute("data-category"))) continue;
+
+										item.addEventListener("click", this.onItemClickQuickEdit);
+									}
+								}
+							},
+						},
+					})
+				);
+
+				for (let id of quick.items) {
+					this.addQuickItem(id, false);
+				}
+			} else {
+				removeContainer("Quick Items");
+			}
+		}
+
+		featureManager.new({
+			name: "Quick Items",
+			scope: "items",
+			enabled: settings.pages.items.quickItems,
+			func: feature,
+			runWhenDisabled: true,
+		});
+	}
+	highlightBloodbags() {
+		featureManager.new({
+			name: "Highlight Bloodbags",
+			scope: "items",
+			enabled: settings.pages.items.highlightBloodBags !== "none",
+			func: feature,
+			runWhenDisabled: true,
+		});
+
+		async function feature() {
+			// noinspection JSIncompatibleTypesComparison
+			if (settings.pages.items.highlightBloodBags !== "none") {
+				const allowedBlood = ALLOWED_BLOOD[settings.pages.items.highlightBloodBags];
+
+				for (let item of document.findAll("ul.items-cont[aria-expanded=true] > li[data-category='Medical']")) {
+					if (!item.find(".name-wrap")) continue;
+					item.find(".name-wrap").classList.remove("good-blood", "bad-blood");
+
+					if (!item.getAttribute("data-sort").includes("Blood Bag : ")) continue; // is not a filled blood bag
+					if (parseInt(item.getAttribute("data-item")) === 1012) continue; // is an irradiated blood bag
+
+					item.find(".name-wrap").classList.add(allowedBlood.includes(parseInt(item.getAttribute("data-item"))) ? "good-blood" : "bad-blood");
+				}
+			} else {
+				for (let bb of document.findAll(".good-blood, .bad-blood")) {
+					bb.classList.remove("good-blood", "bad-blood");
+				}
+			}
+		}
+	}
+	itemValues() {
+		featureManager.new({
+			name: "Item Values",
+			scope: "items",
+			enabled: settings.pages.items.values,
+			func: feature,
+			runWhenDisabled: true,
+		});
+
+		async function feature() {
+			if (settings.pages.items.values && hasAPIData() && settings.apiUsage.user.inventory) {
+				const list = document.find(".items-cont[aria-expanded=true]");
+				const type = list.getAttribute("data-info");
+
+				let total;
+				if (type === "All") total = userdata.inventory.map((x) => x.quantity * x.market_price).reduce((a, b) => (a += b), 0);
+				else
+					total = userdata.inventory
+						.filter((x) => x.type === type)
+						.map((x) => x.quantity * x.market_price)
+						.reduce((a, b) => (a += b), 0);
+
+				for (let item of list.findAll(":scope > li[data-item]")) {
+					const id = item.getAttribute("data-item");
+					const price = torndata.items[id].market_value;
+
+					const parent = mobile ? item.find(".name-wrap") : item.find(".bonuses-wrap") || item.find(".name-wrap");
+
+					const quantity = parseInt(item.find(".item-amount.qty").innerText) || 1;
+					const totalPrice = quantity * parseInt(price);
+
+					if (parent.find(".tt-item-price")) continue;
+
+					let priceElement;
+					if (item.find(".bonuses-wrap")) {
+						priceElement = document.newElement({ type: "li", class: "bonus left tt-item-price" });
+					} else {
+						priceElement = document.newElement({ type: "span", class: "tt-item-price" });
+
+						if (item.find("button.group-arrow")) {
+							priceElement.style.paddingRight = "30px";
 						}
+					}
+					if (mobile) {
+						priceElement.setAttribute("style", `position: absolute; right: -10px; top: 10px; float: unset !important; font-size: 11px;`);
+						parent.find(".name").setAttribute("style", "position: relative; top: -3px;");
+						parent.find(".qty").setAttribute("style", "position: relative; top: -3px;");
+					}
+
+					if (totalPrice) {
+						if (quantity === 1) {
+							priceElement.appendChild(document.newElement({ type: "span", text: `$${formatNumber(price)}` }));
+						} else {
+							priceElement.appendChild(document.newElement({ type: "span", text: `$${formatNumber(price)} | ` }));
+							priceElement.appendChild(document.newElement({ type: "span", text: `${quantity}x = `, class: "tt-item-quantity" }));
+							priceElement.appendChild(document.newElement({ type: "span", text: `$${formatNumber(totalPrice)}` }));
+						}
+					} else if (price === 0) {
+						priceElement.innerText = `N/A`;
+					} else {
+						priceElement.innerText = `$${formatNumber(price)}`;
+					}
+
+					parent.appendChild(priceElement);
+				}
+
+				if (list.find(":scope > li > .tt-item-price")) list.find(":scope > li > .tt-item-price").parentElement.remove();
+
+				list.insertBefore(
+					document.newElement({
+						type: "li",
+						class: "tt-ignore",
+						children: [
+							document.newElement({
+								type: "li",
+								text: `Total Value: $${formatNumber(total, { decimals: 0 })}`,
+								class: "tt-item-price",
+							}),
+						],
+					}),
+					list.firstElementChild
+				);
+			} else {
+				for (const price of document.findAll(".tt-item-price, #category-wrap .tt-ignore")) {
+					price.remove();
+				}
+			}
+		}
+	}
+	itemMarketIcons() {
+		featureManager.new({
+			name: "Item Market Icons",
+			scope: "items",
+			enabled: settings.pages.items.marketLinks,
+			func: feature,
+			runWhenDisabled: true,
+		});
+
+		async function feature() {
+			if (settings.pages.items.marketLinks && !(await checkMobile())) {
+				// TODO - Display market links.
+			} else {
+			}
+		}
+	}
+	drugDetails() {
+		featureManager.new({
+			name: "Drug Details",
+			scope: "items",
+			enabled: settings.pages.items.drugDetails,
+		});
+	}
+
+	// Other content functions
+	requireItemsLoaded() {
+		return requireElement(".items-cont[aria-expanded=true] > li > .title-wrap");
+	}
+	loadItemsOnce() {
+		document.addEventListener("click", (event) => {
+			if (event.target.classList.contains("close-act")) {
+				const responseWrap = findParent(event.target, { class: "response-wrap" });
+
+				if (responseWrap) responseWrap.style.display = "none";
+			}
+		});
+		setInterval(() => {
+			for (let timer of document.findAll(".counter-wrap.tt-modified")) {
+				let secondsLeft;
+				if ("secondsLeft" in timer.dataset) secondsLeft = parseInt(timer.dataset.secondsLeft);
+				else secondsLeft = parseInt(timer.dataset.time);
+				secondsLeft--;
+
+				timer.innerText = formatTime({ seconds: secondsLeft }, { type: "timer" });
+
+				timer.dataset.secondsLeft = `${secondsLeft}`;
+			}
+		}, 1000);
+
+		addXHRListener((event) => {
+			const { page, json, xhr } = event.detail;
+
+			if (page === "item" && json) {
+				const params = new URLSearchParams(xhr.requestBody);
+				const step = params.get("step");
+
+				if (step === "useItem") {
+					if (!json.success) return;
+
+					if (params.get("step") !== "useItem") return;
+					if (params.has("fac") && params.get("fac") !== "0") return;
+
+					if (json.items) {
+						for (const item of json.items.itemAppear) {
+							this.updateItemAmount(parseInt(item.ID), parseInt(item.qty));
+						}
+						for (const item of json.items.itemDisappear) {
+							this.updateItemAmount(parseInt(item.ID), -parseInt(item.qty));
+						}
+					} else {
+						this.updateItemAmount(parseInt(params.get("itemID")), -1);
+					}
+				} else if (step === "sendItemAction") {
+					if (!json.success) return;
+
+					const actionId = json.confirm ? json.itemID : params.get("XID");
+					const item = json.confirm ? params.get("itemID") : pendingActions[actionId].item;
+					const amount = json.amount;
+
+					if (json.confirm) pendingActions[actionId] = { item };
+					else {
+						delete pendingActions[actionId];
+
+						this.updateItemAmount(item, -amount);
+					}
+				} else if (step === "getCategoryList" || step === "getNotAllItemsListWithoutGroups" || step === "getItemsListByItemId") {
+					const tab = document.find("ul.items-cont.tab-menu-cont[style='display: block;'], ul.items-cont.tab-menu-cont:not([style])");
+					if (!tab) return;
+
+					new MutationObserver((mutations, observer) => {
+						if (document.find("li.ajax-item-loader")) return;
+
+						this.init();
+						// highlightBloodBags().catch((error) => console.error("Couldn't highlight the correct blood bags.", error));
+						// showItemValues().catch((error) => console.error("Couldn't show the item values.", error));
+						// showItemMarketIcons().catch((error) => console.error("Couldn't show the market icons.", error));
+
+						observer.disconnect();
+					}).observe(tab, { subtree: true, childList: true });
+				}
+			} else if (page === "inventory" && json) {
+				const params = new URLSearchParams(xhr.requestBody);
+				const step = params.get("step");
+
+				if (step === "info") {
+					this.showDrugDetails(parseInt(params.get("itemID"))).catch((error) => console.error("Couldn't show drug details.", error));
+				}
+			}
+		});
+
+		this.requireItemsLoaded().then(() => {
+			for (let icon of document.findAll("ul[role=tablist] li:not(.no-items):not(.m-show):not(.hide)")) {
+				icon.addEventListener("click", () => this.requireItemsLoaded().then(initializeItems));
+			}
+		});
+	}
+	addQuickItem(id, temporary = false) {
+		const content = findContainer("Quick Items", { selector: ".content" });
+		const innerContent = content.find(".inner-content");
+		const responseWrap = content.find(".response-wrap");
+
+		if (innerContent.find(`.item[item-id='${id}']`)) return;
+		if (!this.allowQuickItem(torndata.items[id].type)) return;
+
+		let itemWrap = document.newElement({
+			type: "div",
+			class: temporary ? "temp item" : "item",
+			attributes: { "item-id": id },
+			events: {
+				click: () => {
+					this.getAction({
+						type: "post",
+						action: "item.php",
+						data: { step: "useItem", id: id, itemID: id },
+						success: (str) => {
+							const response = JSON.parse(str);
+
+							const links = ["<a href='#' class='close-act t-blue h'>Close</a>"];
+							if (response.links) {
+								for (let link of response.links) {
+									links.push(`<a class="t-blue h m-left10 ${link.class}" href="${link.url}" ${link.attr}>${link.title}</a>`);
+								}
+							}
+
+							responseWrap.style.display = "block";
+							responseWrap.innerHTML = `
+								<div class="action-wrap use-act use-action">
+									<form data-action="useItem" method="post">
+										<p>${response.text}</p>
+										<p>${links.join("")}</p>
+										<div class="clear"></div>
+									</form>
+								</div>
+							`;
+
+							for (let count of responseWrap.findAll(".counter-wrap")) {
+								count.classList.add("tt-modified");
+								count.innerText = formatTime({ seconds: parseInt(count.dataset.time) }, { type: "timer" });
+							}
+
+							if (response.items) {
+								for (const item of response.items.itemAppear) {
+									this.updateItemAmount(parseInt(item.ID), parseInt(item.qty));
+								}
+								for (const item of response.items.itemDisappear) {
+									this.updateItemAmount(parseInt(item.ID), -parseInt(item.qty));
+								}
+							} else {
+								this.updateItemAmount(id, -1);
+							}
+						},
+					});
+				},
+			},
+		});
+		itemWrap.appendChild(
+			document.newElement({ type: "div", class: "pic", attributes: { style: `background-image: url(/images/items/${id}/medium.png)` } })
+		);
+		if (hasAPIData()) {
+			itemWrap.appendChild(document.newElement({ type: "div", class: "text", text: torndata.items[id].name }));
+
+			if (settings.apiUsage.user.inventory) {
+				let amount = findItemsInList(userdata.inventory, { ID: id }, { single: true });
+				amount = amount ? amount.quantity : 0;
+
+				itemWrap.appendChild(document.newElement({ type: "div", class: "sub-text quantity", attributes: { quantity: amount }, text: amount + "x" }));
+			}
+		} else {
+			itemWrap.appendChild(document.newElement({ type: "div", class: "text", text: id }));
+		}
+		itemWrap.appendChild(
+			document.newElement({
+				type: "i",
+				class: "fas fa-times tt-close-icon",
+				events: {
+					click: async (event) => {
+						event.stopPropagation();
+						itemWrap.remove();
+
+						await this.saveQuickItems();
 					},
 				},
 			})
 		);
-
-		for (let id of quick.items) {
-			addQuickItem(id, false);
-		}
-	} else {
-		removeContainer("Quick Items");
+		innerContent.appendChild(itemWrap);
 	}
-}
-
-function addQuickItem(id, temporary = false) {
-	const content = findContainer("Quick Items", { selector: ".content" });
-	const innerContent = content.find(".inner-content");
-	const responseWrap = content.find(".response-wrap");
-
-	if (innerContent.find(`.item[item-id='${id}']`)) return;
-	if (!allowQuickItem(torndata.items[id].type)) return;
-
-	let itemWrap = document.newElement({
-		type: "div",
-		class: temporary ? "temp item" : "item",
-		attributes: { "item-id": id },
-		events: {
-			click: () => {
-				getAction({
-					type: "post",
-					action: "item.php",
-					data: { step: "useItem", id: id, itemID: id },
-					success: (str) => {
-						const response = JSON.parse(str);
-
-						const links = ["<a href='#' class='close-act t-blue h'>Close</a>"];
-						if (response.links) {
-							for (let link of response.links) {
-								links.push(`<a class="t-blue h m-left10 ${link.class}" href="${link.url}" ${link.attr}>${link.title}</a>`);
-							}
-						}
-
-						responseWrap.style.display = "block";
-						responseWrap.innerHTML = `
-							<div class="action-wrap use-act use-action">
-								<form data-action="useItem" method="post">
-									<p>${response.text}</p>
-									<p>${links.join("")}</p>
-									<div class="clear"></div>
-								</form>
-							</div>
-						`;
-
-						for (let count of responseWrap.findAll(".counter-wrap")) {
-							count.classList.add("tt-modified");
-							count.innerText = formatTime({ seconds: parseInt(count.dataset.time) }, { type: "timer" });
-						}
-
-						if (response.items) {
-							for (const item of response.items.itemAppear) {
-								updateItemAmount(parseInt(item.ID), parseInt(item.qty));
-							}
-							for (const item of response.items.itemDisappear) {
-								updateItemAmount(parseInt(item.ID), -parseInt(item.qty));
-							}
-						} else {
-							updateItemAmount(id, -1);
-						}
-					},
-				});
-			},
-		},
-	});
-	itemWrap.appendChild(document.newElement({ type: "div", class: "pic", attributes: { style: `background-image: url(/images/items/${id}/medium.png)` } }));
-	if (hasAPIData()) {
-		itemWrap.appendChild(document.newElement({ type: "div", class: "text", text: torndata.items[id].name }));
-
-		if (settings.apiUsage.user.inventory) {
-			let amount = findItemsInList(userdata.inventory, { ID: id }, { single: true });
-			amount = amount ? amount.quantity : 0;
-
-			itemWrap.appendChild(document.newElement({ type: "div", class: "sub-text quantity", attributes: { quantity: amount }, text: amount + "x" }));
-		}
-	} else {
-		itemWrap.appendChild(document.newElement({ type: "div", class: "text", text: id }));
+	allowQuickItem(category) {
+		return ["Medical", "Drug", "Energy Drink", "Alcohol", "Candy", "Booster"].includes(category);
 	}
-	itemWrap.appendChild(
-		document.newElement({
-			type: "i",
-			class: "fas fa-times tt-close-icon",
-			events: {
-				click: async (event) => {
-					event.stopPropagation();
-					itemWrap.remove();
+	async saveQuickItems() {
+		const content = findContainer("Quick Items", { selector: ".content" });
 
-					await saveQuickItems();
-				},
-			},
-		})
-	);
-	innerContent.appendChild(itemWrap);
-}
-
-function allowQuickItem(category) {
-	return ["Medical", "Drug", "Energy Drink", "Alcohol", "Candy", "Booster"].includes(category);
-}
-
-async function saveQuickItems() {
-	const content = findContainer("Quick Items", { selector: ".content" });
-
-	await ttStorage.change({ quick: { items: [...content.findAll(".item")].map((x) => parseInt(x.getAttribute("item-id"))) } });
-}
-
-async function setupQuickDragListeners() {
-	for (let item of document.findAll(".items-cont[aria-expanded=true] > li[data-item]")) {
-		if (!allowQuickItem(item.getAttribute("data-category"))) continue;
-
-		const titleWrap = item.find(".title-wrap");
-
-		titleWrap.setAttribute("draggable", "true");
-		titleWrap.addEventListener("dragstart", onDragStart);
-		titleWrap.addEventListener("dragend", onDragEnd);
+		await ttStorage.change({ quick: { items: [...content.findAll(".item")].map((x) => parseInt(x.getAttribute("item-id"))) } });
 	}
+	async setupQuickDragListeners() {
+		for (let item of document.findAll(".items-cont[aria-expanded=true] > li[data-item]")) {
+			if (!this.allowQuickItem(item.getAttribute("data-category"))) continue;
 
-	function onDragStart(event) {
-		event.dataTransfer.setData("text/plain", null);
+			const titleWrap = item.find(".title-wrap");
 
-		setTimeout(() => {
-			document.find("#quickItems .content").classList.add("drag-progress");
-			if (document.find("#quickItems .temp.item")) return;
-
-			let id = parseInt(event.target.parentElement.getAttribute("data-item"));
-
-			addQuickItem(id, true);
-			// enableInjectListener();
-		}, 10);
-	}
-
-	async function onDragEnd(event) {
-		if (document.find("#quickItems .temp.item")) {
-			document.find("#quickItems .temp.item").remove();
+			titleWrap.setAttribute("draggable", "true");
+			titleWrap.addEventListener("dragstart", onDragStart);
+			titleWrap.addEventListener("dragend", onDragEnd);
 		}
 
-		document.find("#quickItems .content").classList.remove("drag-progress");
+		function onDragStart(event) {
+			event.dataTransfer.setData("text/plain", null);
 
-		await saveQuickItems();
-	}
-}
+			setTimeout(() => {
+				document.find("#quickItems .content").classList.add("drag-progress");
+				if (document.find("#quickItems .temp.item")) return;
 
-async function onItemClickQuickEdit(event) {
-	event.stopPropagation();
-	event.preventDefault();
+				let id = parseInt(event.target.parentElement.getAttribute("data-item"));
 
-	const target = findParent(event.target, { hasAttribute: "data-item" });
-	const id = parseInt(target.getAttribute("data-item"));
+				this.addQuickItem(id, true);
+				// enableInjectListener();
+			}, 10);
+		}
 
-	addQuickItem(id, false);
+		async function onDragEnd(event) {
+			if (document.find("#quickItems .temp.item")) {
+				document.find("#quickItems .temp.item").remove();
+			}
 
-	await saveQuickItems();
-}
+			document.find("#quickItems .content").classList.remove("drag-progress");
 
-function updateItemAmount(id, change) {
-	const quickQuantity = findContainer("Quick Items", { selector: `.item[item-id="${id}"] .quantity` });
-	if (quickQuantity) {
-		let newQuantity = parseInt(quickQuantity.getAttribute("quantity")) + change;
-
-		quickQuantity.innerText = newQuantity + "x";
-		quickQuantity.setAttribute("quantity", newQuantity);
-	}
-
-	for (const item of document.findAll(`.items-cont > li[data-item="${id}"]`)) {
-		const priceElement = item.find(".tt-item-price");
-		if (!priceElement) continue;
-		const quantityElement = priceElement.find(".tt-item-quantity");
-
-		let price = torndata.items[id].market_value;
-		let newQuantity = parseInt(quantityElement.innerText.match(/([0-9]*)x = /i)[1]) + change;
-
-		if (newQuantity === 1) {
-			priceElement.innerHTML = "";
-			priceElement.appendChild(document.newElement({ type: "span", text: `$${formatNumber(price)}` }));
-		} else {
-			quantityElement.innerText = `${newQuantity}x = `;
-			priceElement.find("span:last-child").innerText = `$${formatNumber(price * newQuantity)}`;
+			await this.saveQuickItems();
 		}
 	}
-}
+	async onItemClickQuickEdit(event) {
+		event.stopPropagation();
+		event.preventDefault();
 
-async function showItemValues() {
-	if (settings.pages.items.values && hasAPIData() && settings.apiUsage.user.inventory) {
-		const list = document.find(".items-cont[aria-expanded=true]");
-		const type = list.getAttribute("data-info");
+		const target = findParent(event.target, { hasAttribute: "data-item" });
+		const id = parseInt(target.getAttribute("data-item"));
 
-		let total;
-		if (type === "All") total = userdata.inventory.map((x) => x.quantity * x.market_price).reduce((a, b) => (a += b), 0);
-		else
-			total = userdata.inventory
-				.filter((x) => x.type === type)
-				.map((x) => x.quantity * x.market_price)
-				.reduce((a, b) => (a += b), 0);
+		this.addQuickItem(id, false);
 
-		for (let item of list.findAll(":scope > li[data-item]")) {
-			const id = item.getAttribute("data-item");
-			const price = torndata.items[id].market_value;
+		await this.saveQuickItems();
+	}
+	updateItemAmount(id, change) {
+		const quickQuantity = findContainer("Quick Items", { selector: `.item[item-id="${id}"] .quantity` });
+		if (quickQuantity) {
+			let newQuantity = parseInt(quickQuantity.getAttribute("quantity")) + change;
 
-			const parent = mobile ? item.find(".name-wrap") : item.find(".bonuses-wrap") || item.find(".name-wrap");
+			quickQuantity.innerText = newQuantity + "x";
+			quickQuantity.setAttribute("quantity", newQuantity);
+		}
 
-			const quantity = parseInt(item.find(".item-amount.qty").innerText) || 1;
-			const totalPrice = quantity * parseInt(price);
+		for (const item of document.findAll(`.items-cont > li[data-item="${id}"]`)) {
+			const priceElement = item.find(".tt-item-price");
+			if (!priceElement) continue;
+			const quantityElement = priceElement.find(".tt-item-quantity");
 
-			if (parent.find(".tt-item-price")) continue;
+			let price = torndata.items[id].market_value;
+			let newQuantity = parseInt(quantityElement.innerText.match(/([0-9]*)x = /i)[1]) + change;
 
-			let priceElement;
-			if (item.find(".bonuses-wrap")) {
-				priceElement = document.newElement({ type: "li", class: "bonus left tt-item-price" });
+			if (newQuantity === 1) {
+				priceElement.innerHTML = "";
+				priceElement.appendChild(document.newElement({ type: "span", text: `$${formatNumber(price)}` }));
 			} else {
-				priceElement = document.newElement({ type: "span", class: "tt-item-price" });
-
-				if (item.find("button.group-arrow")) {
-					priceElement.style.paddingRight = "30px";
-				}
+				quantityElement.innerText = `${newQuantity}x = `;
+				priceElement.find("span:last-child").innerText = `$${formatNumber(price * newQuantity)}`;
 			}
-			if (mobile) {
-				priceElement.setAttribute("style", `position: absolute; right: -10px; top: 10px; float: unset !important; font-size: 11px;`);
-				parent.find(".name").setAttribute("style", "position: relative; top: -3px;");
-				parent.find(".qty").setAttribute("style", "position: relative; top: -3px;");
-			}
-
-			if (totalPrice) {
-				if (quantity === 1) {
-					priceElement.appendChild(document.newElement({ type: "span", text: `$${formatNumber(price)}` }));
-				} else {
-					priceElement.appendChild(document.newElement({ type: "span", text: `$${formatNumber(price)} | ` }));
-					priceElement.appendChild(document.newElement({ type: "span", text: `${quantity}x = `, class: "tt-item-quantity" }));
-					priceElement.appendChild(document.newElement({ type: "span", text: `$${formatNumber(totalPrice)}` }));
-				}
-			} else if (price === 0) {
-				priceElement.innerText = `N/A`;
-			} else {
-				priceElement.innerText = `$${formatNumber(price)}`;
-			}
-
-			parent.appendChild(priceElement);
-		}
-
-		if (list.find(":scope > li > .tt-item-price")) list.find(":scope > li > .tt-item-price").parentElement.remove();
-
-		list.insertBefore(
-			document.newElement({
-				type: "li",
-				class: "tt-ignore",
-				children: [
-					document.newElement({
-						type: "li",
-						text: `Total Value: $${formatNumber(total, { decimals: 0 })}`,
-						class: "tt-item-price",
-					}),
-				],
-			}),
-			list.firstElementChild
-		);
-	} else {
-		for (const price of document.findAll(".tt-item-price, #category-wrap .tt-ignore")) {
-			price.remove();
 		}
 	}
-}
+	async showDrugDetails(id) {
+		if (settings.pages.items.drugDetails) {
+			const element = document.find(".show-item-info");
 
-async function showDrugDetails(id) {
-	if (settings.pages.items.drugDetails) {
-		const element = document.find(".show-item-info");
+			requireElement(".ajax-placeholder", { invert: true, parent: element }).then(() => {
+				const details = DRUG_INFORMATION[id];
+				if (!details) return;
 
-		requireElement(".ajax-placeholder", { invert: true, parent: element }).then(() => {
-			const details = DRUG_INFORMATION[id];
-			if (!details) return;
-
-			// Remove current info
-			for (const effect of element.findAll(".item-effect")) {
-				effect.remove();
-			}
-
-			const info = element.find(".info-msg");
-			// Pros
-			if (details.pros) {
-				info.appendChild(document.newElement({ type: "div", class: "item-effect mt10", text: "Pros:", attributes: { color: "tGreen" } }));
-
-				for (let effect of details.pros) {
-					info.appendChild(document.newElement({ type: "div", class: "item-effect tabbed", text: effect, attributes: { color: "tGreen" } }));
+				// Remove current info
+				for (const effect of element.findAll(".item-effect")) {
+					effect.remove();
 				}
-			}
 
-			// Cons
-			if (details.cons) {
-				info.appendChild(document.newElement({ type: "div", class: "item-effect", text: "Con", attributes: { color: "tRed" } }));
+				const info = element.find(".info-msg");
+				// Pros
+				if (details.pros) {
+					info.appendChild(document.newElement({ type: "div", class: "item-effect mt10", text: "Pros:", attributes: { color: "tGreen" } }));
 
-				for (let effect of details.cons) {
-					info.appendChild(document.newElement({ type: "div", class: "item-effect tabbed", text: effect, attributes: { color: "tRed" } }));
-				}
-			}
-
-			// Cooldown
-			if (details.cooldown) {
-				info.appendChild(
-					document.newElement({ type: "div", class: "item-effect", text: `Cooldown: ${details.cooldown}`, attributes: { color: "tRed" } })
-				);
-			}
-
-			// Overdose
-			if (details.overdose) {
-				info.appendChild(document.newElement({ type: "div", class: "item-effect", text: "Overdose:", attributes: { color: "tRed" } }));
-
-				// bars
-				if (details.overdose.bars) {
-					info.appendChild(document.newElement({ type: "div", class: "item-effect tabbed", text: "Bars", attributes: { color: "tRed" } }));
-
-					for (let effect of details.overdose.bars) {
-						info.appendChild(document.newElement({ type: "div", class: "item-effect double-tabbed", text: effect, attributes: { color: "tRed" } }));
+					for (let effect of details.pros) {
+						info.appendChild(document.newElement({ type: "div", class: "item-effect tabbed", text: effect, attributes: { color: "tGreen" } }));
 					}
 				}
 
-				// hospital time
-				if (details.overdose.hosp_time) {
+				// Cons
+				if (details.cons) {
+					info.appendChild(document.newElement({ type: "div", class: "item-effect", text: "Con", attributes: { color: "tRed" } }));
+
+					for (let effect of details.cons) {
+						info.appendChild(document.newElement({ type: "div", class: "item-effect tabbed", text: effect, attributes: { color: "tRed" } }));
+					}
+				}
+
+				// Cooldown
+				if (details.cooldown) {
 					info.appendChild(
-						document.newElement({
-							type: "div",
-							class: "item-effect tabbed",
-							text: `Hospital: ${details.overdose.hosp_time}`,
-							attributes: { color: "tRed" },
-						})
+						document.newElement({ type: "div", class: "item-effect", text: `Cooldown: ${details.cooldown}`, attributes: { color: "tRed" } })
 					);
 				}
 
-				// extra
-				if (details.overdose.extra) {
-					info.appendChild(
-						document.newElement({
-							type: "div",
-							class: "item-effect tabbed",
-							text: `Extra: ${details.overdose.extra}`,
-							attributes: { color: "tRed" },
-						})
-					);
+				// Overdose
+				if (details.overdose) {
+					info.appendChild(document.newElement({ type: "div", class: "item-effect", text: "Overdose:", attributes: { color: "tRed" } }));
+
+					// bars
+					if (details.overdose.bars) {
+						info.appendChild(document.newElement({ type: "div", class: "item-effect tabbed", text: "Bars", attributes: { color: "tRed" } }));
+
+						for (let effect of details.overdose.bars) {
+							info.appendChild(
+								document.newElement({ type: "div", class: "item-effect double-tabbed", text: effect, attributes: { color: "tRed" } })
+							);
+						}
+					}
+
+					// hospital time
+					if (details.overdose.hosp_time) {
+						info.appendChild(
+							document.newElement({
+								type: "div",
+								class: "item-effect tabbed",
+								text: `Hospital: ${details.overdose.hosp_time}`,
+								attributes: { color: "tRed" },
+							})
+						);
+					}
+
+					// extra
+					if (details.overdose.extra) {
+						info.appendChild(
+							document.newElement({
+								type: "div",
+								class: "item-effect tabbed",
+								text: `Extra: ${details.overdose.extra}`,
+								attributes: { color: "tRed" },
+							})
+						);
+					}
 				}
-			}
+			});
+		}
+	}
+
+	// Torn function
+	getAction(options) {
+		options = {
+			success: () => {},
+			action: location.pathname,
+			type: "get",
+			data: {},
+			async: true,
+			...options,
+		};
+
+		return $.ajax({
+			url: "https://www.torn.com/" + addRFC(options.action),
+			type: options.type,
+			data: options.data,
+			async: options.async,
+			success: (msg) => options.success(msg),
+			error: (xhr, ajaxOptions, error) => {
+				console.error("Error during action call.", error);
+			},
 		});
 	}
-}
-
-async function showItemMarketIcons() {
-	if (settings.pages.items.marketLinks && !(await checkMobile())) {
-		// TODO - Display market links.
-	} else {
-	}
-}
-
-async function highlightBloodBags() {
-	// noinspection JSIncompatibleTypesComparison
-	if (settings.pages.items.highlightBloodBags !== "none") {
-		const allowedBlood = ALLOWED_BLOOD[settings.pages.items.highlightBloodBags];
-
-		for (let item of document.findAll("ul.items-cont[aria-expanded=true] > li[data-category='Medical']")) {
-			if (!item.find(".name-wrap")) continue;
-			item.find(".name-wrap").classList.remove("good-blood", "bad-blood");
-
-			if (!item.getAttribute("data-sort").includes("Blood Bag : ")) continue; // is not a filled blood bag
-			if (parseInt(item.getAttribute("data-item")) === 1012) continue; // is an irradiated blood bag
-
-			item.find(".name-wrap").classList.add(allowedBlood.includes(parseInt(item.getAttribute("data-item"))) ? "good-blood" : "bad-blood");
-		}
-	} else {
-		for (let bb of document.findAll(".good-blood, .bad-blood")) {
-			bb.classList.remove("good-blood", "bad-blood");
-		}
-	}
-}
-
-/*
- * Torn Function
- */
-function getAction(options) {
-	options = {
-		success: () => {},
-		action: location.pathname,
-		type: "get",
-		data: {},
-		async: true,
-		...options,
-	};
-
-	return $.ajax({
-		url: "https://www.torn.com/" + addRFC(options.action),
-		type: options.type,
-		data: options.data,
-		async: options.async,
-		success: (msg) => options.success(msg),
-		error: (xhr, ajaxOptions, error) => {
-			console.error("Error during action call.", error);
-		},
-	});
 }

--- a/extension/scripts/content/items/ttItems.js
+++ b/extension/scripts/content/items/ttItems.js
@@ -9,9 +9,8 @@ let pendingActions = {};
 	let itemsFeatures = new ItemsFeatures();
 	itemsFeatures.init();
 
-	storageListeners.settings.push(function () {
+	storageListeners.settings.push(() => {
 		itemsFeatures.init();
-		featureManager.display(settings.featureDisplay);
 	});
 
 	itemsFeatures.loadItemsOnce();

--- a/extension/scripts/content/items/ttItems.js
+++ b/extension/scripts/content/items/ttItems.js
@@ -11,6 +11,7 @@ let pendingActions = {};
 
 	storageListeners.settings.push(function () {
 		itemsFeatures.init();
+		featureManager.display(settings.featureDisplay);
 	});
 
 	itemsFeatures.loadItemsOnce();
@@ -90,7 +91,7 @@ class ItemsFeatures {
 			} else {
 				removeContainer("Quick Items");
 			}
-		}
+		};
 
 		featureManager.new({
 			name: "Quick Items",

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -7,3 +7,105 @@ class DefaultSetting {
 		}
 	}
 }
+
+class FeatureManager {
+	/*
+		feature = {
+			name: string,
+			enabled: boolean,
+			func: function,
+			runWhenDisabled: boolean
+		}
+	*/
+	constructor() {
+		this.features = [];
+		this.createPopup();
+	}
+
+	createPopup() {
+		document.find('.content').appendChild(document.newElement({
+			id: 'tt-page-status',
+			type: 'div',
+			children: [
+				document.newElement({
+					type: 'div',
+					class: 'tt-page-status-header',
+					children: [
+						document.newElement({
+							type: 'span',
+							text: 'TornTools activated'
+						}),
+						document.newElement({
+							type: 'i',
+							class: 'icon fas fa-caret-down'
+						})
+					]
+				})
+			]
+		}));
+	}
+
+	async load(feature) {
+		console.log('Loading feature:', feature.name);
+		for (let _feature in this.features) {
+			if (_feature.name === feature.name) {
+				_feature = feature;  // Update the previous entry
+			}
+		}
+
+		if (!feature.enabled) {
+			console.log('Feature disabled:', feature.name);
+			this.addResult({ enabled: false, name: feature.name });
+			if (feature.runWhenDisabled) feature.func();
+			return;
+		}
+
+		await new Promise((resolve, reject) => {
+			feature.func()
+				.then(() => {
+					console.log('Successfully loaded feature:', feature.name);
+					this.addResult({ success: true, name: feature.name })
+					return resolve();
+				})
+				.catch(error => {
+					console.log('Feature failed to load:', error);
+					this.addResult({ success: false, name: feature.name })
+					return resolve();
+				})
+		});
+	}
+
+	reload(name) {
+		console.log('reloading', name);
+		for (let _feature in this.features) {
+			if (_feature.name === name) {
+				console.log('found', _feature);
+				this.load(_feature);
+			}
+		}
+	}
+
+	addResult(options) {
+		let newRow;
+		if (document.find(`tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, '-')}`)) {
+			newRow = document.find(`tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, '-')}`);
+		} else {
+			newRow = document.newElement({
+				type: 'div',
+				class: 'tt-page-status-feature',
+				id: `tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, '-')}`
+			});
+			document.find(`#tt-page-status`).appendChild(newRow);
+		}
+
+		if (options.enabled === false) newRow.innerHTML = `<span class="tt-page-status-feature-icon disabled"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+		else if (options.success) newRow.innerHTML = `<span class="tt-page-status-feature-icon success"><i class="fas fa-check"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+		else newRow.innerHTML = `<span class="tt-page-status-feature-icon failed"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+	}
+
+	clear() {
+		for (let element of document.findAll('.tt-page-status-feature')) {
+			element.remove();
+		}
+	}
+}

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -68,7 +68,7 @@ class FeatureManager {
 					return resolve();
 				})
 				.catch(error => {
-					console.log('Feature failed to load:', error);
+					console.error('Feature failed to load:', error);
 					this.addResult({ success: false, name: feature.name })
 					return resolve();
 				})

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -23,63 +23,78 @@ class FeatureManager {
 	}
 
 	createPopup() {
-		document.find('.content').appendChild(document.newElement({
-			id: 'tt-page-status',
-			type: 'div',
-			children: [
-				document.newElement({
-					type: 'div',
-					class: 'tt-page-status-header',
-					children: [
-						document.newElement({
-							type: 'span',
-							text: 'TornTools activated'
-						}),
-						document.newElement({
-							type: 'i',
-							class: 'icon fas fa-caret-down'
-						})
-					]
-				})
-			]
-		}));
+		let containerID = "tt-page-status";
+		let collapsed = containerID in filters.containers ? filters.containers[containerID] : false;
+
+		document.find(".content").appendChild(
+			document.newElement({
+				id: containerID,
+				type: "div",
+				children: [
+					document.newElement({
+						type: "div",
+						class: `tt-page-status-header ${collapsed ? "collapsed" : ""}`,
+						children: [
+							document.newElement({
+								type: "span",
+								text: "TornTools activated",
+							}),
+							document.newElement({
+								type: "i",
+								class: "icon fas fa-caret-down",
+							}),
+						],
+					}),
+					document.newElement({
+						type: "div",
+						class: "tt-page-status-content",
+					}),
+				],
+			})
+		);
+
+		document.find(".tt-page-status-header").onclick = function () {
+			this.classList.toggle("collapsed");
+			ttStorage.change({ filters: { containers: { [containerID]: this.classList.contains("collapsed") } } });
+		};
 	}
 
 	async load(feature) {
-		console.log('Loading feature:', feature.name);
+		console.log("Loading feature:", feature.name);
 		for (let _feature in this.features) {
 			if (_feature.name === feature.name) {
-				_feature = feature;  // Update the previous entry
+				_feature = feature; // Update the previous entry
 			}
 		}
 
 		if (!feature.enabled) {
-			console.log('Feature disabled:', feature.name);
+			console.log("Feature disabled:", feature.name);
 			this.addResult({ enabled: false, name: feature.name });
 			if (feature.runWhenDisabled) feature.func();
 			return;
 		}
 
 		await new Promise((resolve, reject) => {
-			feature.func()
+			feature
+				.func()
 				.then(() => {
-					console.log('Successfully loaded feature:', feature.name);
-					this.addResult({ success: true, name: feature.name })
+					console.log("Successfully loaded feature:", feature.name);
+					this.addResult({ success: true, name: feature.name });
 					return resolve();
 				})
-				.catch(error => {
-					console.error('Feature failed to load:', error);
-					this.addResult({ success: false, name: feature.name })
+				.catch((error) => {
+					console.error("Feature failed to load:", error);
+					this.addResult({ success: false, name: feature.name });
 					return resolve();
-				})
+				});
 		});
 	}
 
 	reload(name) {
-		console.log('reloading', name);
+		console.log("reloading", name);
 		for (let _feature in this.features) {
 			if (_feature.name === name) {
-				console.log('found', _feature);
+				console.log("found", _feature);
 				this.load(_feature);
 			}
 		}
@@ -87,24 +102,27 @@ class FeatureManager {
 
 	addResult(options) {
 		let newRow;
-		if (document.find(`tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, '-')}`)) {
-			newRow = document.find(`tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, '-')}`);
+		if (document.find(`tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, "-")}`)) {
+			newRow = document.find(`tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, "-")}`);
 		} else {
 			newRow = document.newElement({
-				type: 'div',
-				class: 'tt-page-status-feature',
-				id: `tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, '-')}`
+				type: "div",
+				class: "tt-page-status-feature",
+				id: `tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, "-")}`,
 			});
-			document.find(`#tt-page-status`).appendChild(newRow);
+			document.find(`.tt-page-status-content`).appendChild(newRow);
 		}
 
-		if (options.enabled === false) newRow.innerHTML = `<span class="tt-page-status-feature-icon disabled"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
-		else if (options.success) newRow.innerHTML = `<span class="tt-page-status-feature-icon success"><i class="fas fa-check"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
-		else newRow.innerHTML = `<span class="tt-page-status-feature-icon failed"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+		if (options.enabled === false)
+			newRow.innerHTML = `<span class="tt-page-status-feature-icon disabled"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+		else if (options.success)
+			newRow.innerHTML = `<span class="tt-page-status-feature-icon success"><i class="fas fa-check"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+		else
+			newRow.innerHTML = `<span class="tt-page-status-feature-icon failed"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
 	}
 
 	clear() {
-		for (let element of document.findAll('.tt-page-status-feature')) {
+		for (let element of document.findAll(".tt-page-status-feature")) {
 			element.remove();
 		}
 	}

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -28,7 +28,7 @@ class FeatureManager {
 
 	display(show) {
 		try {
-			document.find(`#${this.containerID}`).setAttribute('class', `${show? '':'hidden'} ${settings.featureDisplayPosition}`);
+			document.find(`#${this.containerID}`).setAttribute("class", `${show ? "" : "hidden"} ${settings.featureDisplayPosition}`);
 		} catch (err) {}
 	}
 
@@ -65,9 +65,9 @@ class FeatureManager {
 			})
 		);
 
-		document.find(".tt-page-status-header").onclick = function () {
-			this.classList.toggle("collapsed");
-			ttStorage.change({ filters: { containers: { [this.containerID]: this.classList.contains("collapsed") } } });
+		document.find(".tt-page-status-header").onclick = () => {
+			document.find(".tt-page-status-header").classList.toggle("collapsed");
+			ttStorage.change({ filters: { containers: { [this.containerID]: document.find(".tt-page-status-header").classList.contains("collapsed") } } });
 		};
 
 		this.popupLoaded = true;

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -67,7 +67,7 @@ class FeatureManager {
 
 		document.find(".tt-page-status-header").onclick = function () {
 			this.classList.toggle("collapsed");
-			ttStorage.change({ filters: { containers: { [containerID]: this.classList.contains("collapsed") } } });
+			ttStorage.change({ filters: { containers: { [this.containerID]: this.classList.contains("collapsed") } } });
 		};
 
 		this.popupLoaded = true;

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -26,10 +26,17 @@ class FeatureManager {
 		this.containerID = "tt-page-status";
 	}
 
-	display(show) {
-		try {
-			document.find(`#${this.containerID}`).setAttribute("class", `${show ? "" : "hidden"} ${settings.featureDisplayPosition}`);
-		} catch (err) {}
+	display() {
+		let container = document.find(`#${this.containerID}`);
+		if (!container) return;
+
+		container.setAttribute(
+			"class",
+			`${settings.featureDisplay ? "" : "hidden"}
+			${settings.featureDisplayPosition}
+			${settings.featureDisplayOnlyFails ? "only-fails" : ""}
+			${settings.featureDisplayHideDisabled ? "hide-disabled" : ""}`
+		);
 	}
 
 	async createPopup() {
@@ -107,14 +114,14 @@ class FeatureManager {
 		// Feature is disabled
 		if (!feature.enabled) {
 			console.log("Feature disabled:", feature.name);
-			this.addResult({ enabled: false, name: feature.name, scope: feature.scope });
+			this.addResult({ enabled: false, name: feature.name, scope: feature.scope, status: 'disabled' });
 			if (feature.runWhenDisabled) feature.func();
 			return;
 		}
 
 		// Feature enabled but no func to run
 		if (!feature.func) {
-			this.addResult({ success: true, name: feature.name, scope: feature.scope });
+			this.addResult({ success: true, name: feature.name, scope: feature.scope, status: 'loaded' });
 			return;
 		}
 
@@ -123,12 +130,12 @@ class FeatureManager {
 				.func()
 				.then(() => {
 					console.log("Successfully loaded feature:", feature.name);
-					this.addResult({ success: true, name: feature.name, scope: feature.scope });
+					this.addResult({ success: true, name: feature.name, scope: feature.scope, status: 'loaded' });
 					return resolve();
 				})
 				.catch((error) => {
 					console.error("Feature failed to load:", error);
-					this.addResult({ success: false, name: feature.name, scope: feature.scope });
+					this.addResult({ success: false, name: feature.name, scope: feature.scope, status: 'failed' });
 					return resolve();
 				});
 		});
@@ -154,7 +161,7 @@ class FeatureManager {
 		} else {
 			row = document.newElement({
 				type: "div",
-				class: "tt-page-status-feature",
+				class: `tt-page-status-feature ${options.status}`,
 				id: `tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, "-")}`,
 			});
 

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -107,14 +107,14 @@ class FeatureManager {
 		// Feature is disabled
 		if (!feature.enabled) {
 			console.log("Feature disabled:", feature.name);
-			this.addResult({ enabled: false, name: feature.name });
+			this.addResult({ enabled: false, name: feature.name, scope: feature.scope });
 			if (feature.runWhenDisabled) feature.func();
 			return;
 		}
 
 		// Feature enabled but no func to run
 		if (!feature.func) {
-			this.addResult({ success: true, name: feature.name });
+			this.addResult({ success: true, name: feature.name, scope: feature.scope });
 			return;
 		}
 
@@ -123,12 +123,12 @@ class FeatureManager {
 				.func()
 				.then(() => {
 					console.log("Successfully loaded feature:", feature.name);
-					this.addResult({ success: true, name: feature.name });
+					this.addResult({ success: true, name: feature.name, scope: feature.scope });
 					return resolve();
 				})
 				.catch((error) => {
 					console.error("Feature failed to load:", error);
-					this.addResult({ success: false, name: feature.name });
+					this.addResult({ success: false, name: feature.name, scope: feature.scope });
 					return resolve();
 				});
 		});
@@ -148,24 +148,39 @@ class FeatureManager {
 			return;
 		}
 
-		let newRow;
+		let row;
 		if (document.find(`#tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, "-")}`)) {
-			newRow = document.find(`#tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, "-")}`);
+			row = document.find(`#tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, "-")}`);
 		} else {
-			newRow = document.newElement({
+			row = document.newElement({
 				type: "div",
 				class: "tt-page-status-feature",
 				id: `tt-page-status-feature-${options.name.toLowerCase().replace(/ /g, "-")}`,
 			});
-			document.find(`.tt-page-status-content`).appendChild(newRow);
+
+			if (!document.find(`.tt-page-status-content #scope-${options.scope}`)) {
+				let scopeElement = document.newElement({
+					type: "div",
+					id: "scope-" + options.scope,
+				});
+				scopeElement.appendChild(
+					document.newElement({
+						type: "div",
+						class: "tt-page-status-scope-heading",
+						text: `— ${options.scope} —`,
+					})
+				);
+				document.find(".tt-page-status-content").appendChild(scopeElement);
+			}
+			document.find(`.tt-page-status-content #scope-${options.scope}`).appendChild(row);
 		}
 
 		if (options.enabled === false)
-			newRow.innerHTML = `<span class="tt-page-status-feature-icon disabled"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+			row.innerHTML = `<span class="tt-page-status-feature-icon disabled"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
 		else if (options.success)
-			newRow.innerHTML = `<span class="tt-page-status-feature-icon success"><i class="fas fa-check"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+			row.innerHTML = `<span class="tt-page-status-feature-icon success"><i class="fas fa-check"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
 		else
-			newRow.innerHTML = `<span class="tt-page-status-feature-icon failed"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
+			row.innerHTML = `<span class="tt-page-status-feature-icon failed"><i class="fas fa-times-circle"></i></span><span class='tt-page-status-feature-text'>${options.name}</span>`;
 	}
 
 	removeResult(name) {

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -28,8 +28,7 @@ class FeatureManager {
 
 	display(show) {
 		try {
-			if (show) document.find(`#${this.containerID}`).classList.remove("hidden");
-			else document.find(`#${this.containerID}`).classList.add("hidden");
+			document.find(`#${this.containerID}`).setAttribute('class', `${show? '':'hidden'} ${settings.featureDisplayPosition}`);
 		} catch (err) {}
 	}
 
@@ -38,10 +37,11 @@ class FeatureManager {
 
 		let collapsed = this.containerID in filters.containers ? filters.containers[this.containerID] : false;
 
-		document.find(".content").appendChild(
+		document.find("body").appendChild(
 			document.newElement({
 				id: this.containerID,
 				type: "div",
+				class: settings.featureDisplayPosition,
 				children: [
 					document.newElement({
 						type: "div",

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -37,7 +37,7 @@ class FeatureManager {
 
 		let collapsed = this.containerID in filters.containers ? filters.containers[this.containerID] : false;
 
-		document.find("body").appendChild(
+		document.body.appendChild(
 			document.newElement({
 				id: this.containerID,
 				type: "div",

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -25,7 +25,9 @@ class FeatureManager {
 		this.resultQueue = [];
 	}
 
-	createPopup() {
+	async createPopup() {
+		if (await checkMobile()) return;
+
 		let containerID = "tt-page-status";
 		let collapsed = containerID in filters.containers ? filters.containers[containerID] : false;
 
@@ -127,11 +129,13 @@ class FeatureManager {
 
 	reload(name) {
 		console.log("Reloading feature:", name);
-		let feature = this.findFeatureByName(name);
-		this.load(feature);
+		// let feature = this.findFeatureByName(name);
+		this.load(name);
 	}
 
-	addResult(options) {
+	async addResult(options) {
+		if (await checkMobile()) return;
+
 		if (!this.popupLoaded) {
 			this.resultQueue.push(options);
 			return;

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -66,8 +66,8 @@ class FeatureManager {
 		);
 
 		document.find(".tt-page-status-header").onclick = () => {
-			document.find(".tt-page-status-header").classList.toggle("collapsed");
-			ttStorage.change({ filters: { containers: { [this.containerID]: document.find(".tt-page-status-header").classList.contains("collapsed") } } });
+			let toggleResult = document.find(".tt-page-status-header").classList.toggle("collapsed");
+			ttStorage.change({ filters: { containers: { [this.containerID]: toggleResult } } });
 		};
 
 		this.popupLoaded = true;

--- a/extension/scripts/global/globalClasses.js
+++ b/extension/scripts/global/globalClasses.js
@@ -23,17 +23,24 @@ class FeatureManager {
 		this.features = [];
 		this.popupLoaded = false;
 		this.resultQueue = [];
+		this.containerID = "tt-page-status";
+	}
+
+	display(show) {
+		try {
+			if (show) document.find(`#${this.containerID}`).classList.remove("hidden");
+			else document.find(`#${this.containerID}`).classList.add("hidden");
+		} catch (err) {}
 	}
 
 	async createPopup() {
 		if (await checkMobile()) return;
 
-		let containerID = "tt-page-status";
-		let collapsed = containerID in filters.containers ? filters.containers[containerID] : false;
+		let collapsed = this.containerID in filters.containers ? filters.containers[this.containerID] : false;
 
 		document.find(".content").appendChild(
 			document.newElement({
-				id: containerID,
+				id: this.containerID,
 				type: "div",
 				children: [
 					document.newElement({

--- a/extension/scripts/global/globalData.js
+++ b/extension/scripts/global/globalData.js
@@ -121,6 +121,7 @@ const DEFAULT_STORAGE = {
 	settings: {
 		updateNotice: new DefaultSetting({ type: "boolean", defaultValue: true }),
 		featureDisplay: new DefaultSetting({ type: "boolean", defaultValue: true }),
+		featureDisplayPosition: new DefaultSetting({ type: "string", defaultValue: "bottom-left" }),
 		developer: new DefaultSetting({ type: "boolean", defaultValue: false }),
 		formatting: {
 			date: new DefaultSetting({ type: "string", defaultValue: "eu" }),

--- a/extension/scripts/global/globalData.js
+++ b/extension/scripts/global/globalData.js
@@ -122,6 +122,8 @@ const DEFAULT_STORAGE = {
 		updateNotice: new DefaultSetting({ type: "boolean", defaultValue: true }),
 		featureDisplay: new DefaultSetting({ type: "boolean", defaultValue: true }),
 		featureDisplayPosition: new DefaultSetting({ type: "string", defaultValue: "bottom-left" }),
+		featureDisplayOnlyFailed: new DefaultSetting({ type: "boolean", defaultValue: false }),
+		featureDisplayHideDisabled: new DefaultSetting({ type: "boolean", defaultValue: false }),
 		developer: new DefaultSetting({ type: "boolean", defaultValue: false }),
 		formatting: {
 			date: new DefaultSetting({ type: "string", defaultValue: "eu" }),

--- a/extension/scripts/global/globalData.js
+++ b/extension/scripts/global/globalData.js
@@ -120,6 +120,7 @@ const DEFAULT_STORAGE = {
 	},
 	settings: {
 		updateNotice: new DefaultSetting({ type: "boolean", defaultValue: true }),
+		featureDisplay: new DefaultSetting({ type: "boolean", defaultValue: true }),
 		developer: new DefaultSetting({ type: "boolean", defaultValue: false }),
 		formatting: {
 			date: new DefaultSetting({ type: "string", defaultValue: "eu" }),

--- a/extension/scripts/global/globalFunctions.js
+++ b/extension/scripts/global/globalFunctions.js
@@ -1220,3 +1220,13 @@ function addRFC(url) {
 	url += (url.split("?").length > 1 ? "&" : "?") + "rfcv=" + getRFC();
 	return url;
 }
+
+function newFeature(name, scope, enabled, excecute) {
+	return {
+		name,
+		scope,
+		enabled,
+		func: excecute,
+		runWhenDisabled: true,
+	};
+}

--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -301,14 +301,31 @@
 /* Feature Status popup */
 
 #tt-page-status {
-	position: absolute;
-	top: 80px;
-	right: 100px;
 	background-color: white;
 	padding: 7px 14px;
 	width: 150px;
 	border-radius: 10px;
 	border: 2px solid lightgray;
+}
+#tt-page-status.top-left {
+	position: absolute;
+	top: 90px;
+	left: 16px;
+}
+#tt-page-status.top-right {
+	position: absolute;
+	top: 90px;
+	right: 16px;
+}
+#tt-page-status.bottom-left {
+	position: fixed;
+	left: 16px;
+	bottom: 16px;
+}
+#tt-page-status.bottom-right {
+	position: fixed;
+	right: 16px;
+	bottom: 50px;
 }
 #tt-page-status.hidden {
 	display: none;

--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -310,6 +310,9 @@
 	border-radius: 10px;
 	border: 2px solid lightgray;
 }
+#tt-page-status.hidden {
+	display: none;
+}
 
 .tt-page-status-header {
 	border-bottom: 2px solid lightgray;

--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -333,6 +333,9 @@
 	width: 100%;
 }
 
+.tt-page-status-feature {
+	padding: 1px 0;
+}
 .tt-page-status-feature-icon i {
 	margin-right: 3px;
 }

--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -329,6 +329,12 @@
 #tt-page-status.hidden {
 	display: none;
 }
+#tt-page-status.only-fails .tt-page-status-feature:not(.failed) {
+	display: none;
+}
+#tt-page-status.hide-disabled .tt-page-status-feature.disabled {
+	display: none;
+}
 .tt-page-status-header {
 	border-bottom: 2px solid lightgray;
 	font-weight: 600;

--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -302,13 +302,13 @@
 
 #tt-page-status {
 	position: absolute;
-    top: 80px;
-    right: 100px;
-    background-color: white;
-    padding: 7px 14px;
+	top: 80px;
+	right: 100px;
+	background-color: white;
+	padding: 7px 14px;
 	width: 150px;
-    border-radius: 10px;
-    border: 2px solid lightgray;
+	border-radius: 10px;
+	border: 2px solid lightgray;
 }
 
 .tt-page-status-header {
@@ -317,6 +317,17 @@
 	margin-bottom: 5px;
 	display: inline-flex;
 	width: 100%;
+	cursor: pointer;
+}
+.tt-page-status-header.collapsed {
+	border-bottom: none;
+	margin-bottom: 0;
+}
+.tt-page-status-header.collapsed + .tt-page-status-content {
+	display: none;
+}
+.tt-page-status-header.collapsed i {
+	transform: rotate(-90deg);
 }
 .tt-page-status-header span {
 	width: 100%;

--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -299,7 +299,6 @@
 }
 
 /* Feature Status popup */
-
 #tt-page-status {
 	background-color: white;
 	padding: 7px 14px;
@@ -330,7 +329,6 @@
 #tt-page-status.hidden {
 	display: none;
 }
-
 .tt-page-status-header {
 	border-bottom: 2px solid lightgray;
 	font-weight: 600;
@@ -352,7 +350,11 @@
 .tt-page-status-header span {
 	width: 100%;
 }
-
+.tt-page-status-scope-heading {
+	text-align: center;
+	font-style: italic;
+	margin-bottom: 3px;
+}
 .tt-page-status-feature {
 	padding: 1px 0;
 }

--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -297,3 +297,40 @@
 .tt-container .content.background {
 	background-color: var(--default-bg-panel-color, #f2f2f2);
 }
+
+/* Feature Status popup */
+
+#tt-page-status {
+	position: absolute;
+    top: 80px;
+    right: 100px;
+    background-color: white;
+    padding: 7px 14px;
+	width: 150px;
+    border-radius: 10px;
+    border: 2px solid lightgray;
+}
+
+.tt-page-status-header {
+	border-bottom: 2px solid lightgray;
+	font-weight: 600;
+	margin-bottom: 5px;
+	display: inline-flex;
+	width: 100%;
+}
+.tt-page-status-header span {
+	width: 100%;
+}
+
+.tt-page-status-feature-icon i {
+	margin-right: 3px;
+}
+.tt-page-status-feature-icon.disabled i {
+	color: orange;
+}
+.tt-page-status-feature-icon.failed i {
+	color: red;
+}
+.tt-page-status-feature-icon.success i {
+	color: green;
+}


### PR DESCRIPTION
Every page using FeatureManager should run it at the start using `let featureManager = new FeatureManager();`. I didn't test it but I think it's better to isolate it to certain pages rather than running in global scope.

Instead of running page's content like this:
```
requireContent().then(async () => {
		await displayNetworth().catch((error) => console.error("Couldn't load the live networth.", error));
		await displayEffectiveBattleStats().catch((error) => console.error("Couldn't load the effective battle stats.", error));
	});
```
It will be run as (FeatureManager will log any errors so no need to catch them):
```
requireContent().then(async () => {
		featureManager.clear();
		featureManager.load({
			name: 'Live Networth',
			enabled: !!(settings.apiUsage.user.networth && settings.pages.home.networthDetails && hasAPIData()),
			func: displayNetworth,
			runWhenDisabled: true
		});
		featureManager.load({
			name: 'Effective Battle Stats',
			enabled: settings.pages.home.effectiveStats,
			func: displayEffectiveBattleStats,
			runWhenDisabled: true
		});
	});
```
This will create new items in the FeatureManager. Following is the current format how a feature is added:
```
feature = {
	name: string,
	enabled: boolean,
	func: function,
	runWhenDisabled: boolean
}
```

I tested it a bit and it runs smoothly live when changing settings on the preferences page.