### PR TITLE
Hide Features not available on mobile

### DIFF
--- a/extension/pages/settings/preferences.css
+++ b/extension/pages/settings/preferences.css
@@ -265,3 +265,7 @@ body.dark #preferences #hide-casino-games span {
 #featureDisplayDemo .right {
 	right: 1px;
 }
+
+body.tt-mobile .no-mobile {
+	display: none !important;
+}

--- a/extension/pages/settings/settings.html
+++ b/extension/pages/settings/settings.html
@@ -112,7 +112,7 @@
 				<div class="sections advanced-hidden">
 					<section class="active" name="general">
 						<div class="header">General</div>
-						<div class="option">
+						<div class="option no-mobile">
 							<input id="updateNotice" type="checkbox" />
 							<label for="updateNotice">Show update notice.</label>
 						</div>
@@ -353,15 +353,15 @@
 					</section>
 					<section name="sidebar">
 						<div class="header">Sidebar</div>
-						<div class="option">
+						<div class="option no-mobile">
 							<input id="sidebar-notes" type="checkbox" />
 							<label for="sidebar-notes">Show a notes panel.</label>
 						</div>
-						<div class="option">
+						<div class="option no-mobile">
 							<input id="sidebar-collapseAreas" type="checkbox" />
 							<label for="sidebar-collapseAreas">Collapse areas section.</label>
 						</div>
-						<div class="option">
+						<div class="option no-mobile">
 							<input id="sidebar-ocTimer" type="checkbox" />
 							<label for="sidebar-ocTimer">Show OC ready time in sidebar.</label>
 							<br />
@@ -371,7 +371,7 @@
 							<input id="sidebar-hideGymHighlight" type="checkbox" />
 							<label for="sidebar-hideGymHighlight">Hide gym highlighting.</label>
 						</div>
-						<div class="option">
+						<div class="option no-mobile">
 							<label for="sidebar-upkeepPropHighlight">Highlight properties link when upkeep is greater than</label>
 							<input id="sidebar-upkeepPropHighlight" type="number" />
 						</div>
@@ -681,7 +681,7 @@
 							<br />
 							<label for="items-highlightBloodBags" class="tabbed note">Also affects the faction armory.</label>
 						</div>
-						<div class="option">
+						<div class="option no-mobile">
 							<input id="items-marketLinks" type="checkbox" />
 							<label for="items-marketLinks">Add link icons to the item market.</label>
 						</div>


### PR DESCRIPTION
Hidden features on mobile:

1. Show Update Notice
2. Sidebar Notes
3. Collapse Areas
4. OC Timer
5. Highlight properties link
6. Add link icons to the item market