### PR TITLE
Fix page status wrong bottom style while in bottom-left position

### DIFF
--- a/extension/scripts/global/globalStyle.css
+++ b/extension/scripts/global/globalStyle.css
@@ -264,16 +264,18 @@ body.scrolled #tt-page-status.top-right {
 	top: 16px;
 }
 
-#tt-page-status.bottom-left {
+#tt-page-status.bottom-left,
+#tt-page-status.bottom-right {
 	position: fixed;
+	bottom: 50px;
+}
+
+#tt-page-status.bottom-left {
 	left: 16px;
-	bottom: 16px;
 }
 
 #tt-page-status.bottom-right {
-	position: fixed;
 	right: 16px;
-	bottom: 50px;
 }
 
 #tt-page-status.hidden,


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/30085989/119138976-29b56780-ba4b-11eb-9714-f2fc71c5cbd9.png)
After:
![image](https://user-images.githubusercontent.com/30085989/119139006-35a12980-ba4b-11eb-85be-b65df4f0793a.png)
