### PR TITLE
Bazaar Worth Disappear Fix

### DIFF
--- a/extension/scripts/features/bazaar-worth/ttBazaarWorth.js
+++ b/extension/scripts/features/bazaar-worth/ttBazaarWorth.js
@@ -17,7 +17,7 @@
 	);
 
 	async function addWorth() {
-		await requireElement(".info-msg-cont .msg");
+		await requireElement(".info-msg-cont .msg a[href]");
 		const bazaarUserId = getSearchParameters().get("userId");
 
 		if (ttCache.hasValue("bazaar", bazaarUserId)) {


### PR DESCRIPTION
Closes #313 .

Might be due to ReactJS's internal DOM states. Because JS waits only upto `.msg` appearing, TT adds the worth but the React repaints the DOM so worth disappears.